### PR TITLE
Fix host prefered array allocation

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/galaxy.yml
+++ b/collections/ansible_collections/purestorage/flasharray/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purestorage
 name: flasharray
-version: 1.1.4
+version: 1.1.5
 readme: README.md
 authors:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_host.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_host.py
@@ -452,12 +452,13 @@ def main():
                 if not all_connected_arrays:
                     module.fail_json(msg='No target arrays connected to source array - preferred arrays not possible.')
                 else:
-                    current_arrays = []
+                    current_arrays = [array.get()['array_name']]
                     for current_array in range(0, len(all_connected_arrays)):
-                        current_arrays.append(all_connected_arrays[current_array]['array_name'])
+                        if all_connected_arrays[current_array]['type'] == "sync-replication":
+                            current_arrays.append(all_connected_arrays[current_array]['array_name'])
                 for array_to_connect in range(0, len(module.params['preferred_array'])):
                     if module.params['preferred_array'][array_to_connect] not in current_arrays:
-                        module.fail_json(msg='Array {0} not in existing array connections.'.format(module.params['preferred_array'][array_to_connect]))
+                        module.fail_json(msg='Array {0} is not a synchronously connected array.'.format(module.params['preferred_array'][array_to_connect]))
         except Exception:
             module.fail_json(msg='Failed to get existing array connections.')
 


### PR DESCRIPTION
##### SUMMARY
Ensure that the current array is part of the approved arrays to add as a preferred array.
Ensure that remote preferred arrays are sync-rep. Async-rep not supported as a preferred array

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_host.py