### PR TITLE
Add support deletion of snapshots from an offload target protection group

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_snap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_snap.py
@@ -120,8 +120,8 @@ def get_snapshot(module, array):
     """Return Snapshot or None"""
     try:
         snapname = module.params['name'] + "." + module.params['suffix']
-        for s in array.get_volume(module.params['name'], snap='true'):
-            if s['name'] == snapname:
+        for snaps in array.get_volume(module.params['name'], snap='true'):
+            if snaps['name'] == snapname:
                 return snapname
     except Exception:
         return None


### PR DESCRIPTION
##### SUMMARY
Add feature to be able to delete snapshots on offload target protection groups.
Also, fix a stylist error with a variable name

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_pgsnap.py
purefa_snap.py

##### ADDITIONAL INFORMATION
Use the `on` parameter to specify the offload target name and ensure that the snapshot name
is of the format `<arrayname>:<pgname>` and a correct `suffix` is provided