### PR TITLE
Fix SNMP delete issue

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/docs/purefa_snmp.rst
+++ b/collections/ansible_collections/purestorage/flasharray/docs/purefa_snmp.rst
@@ -54,7 +54,7 @@ Parameters
     SNMP v3 only. Hash algorithm to use
 
 
-  host (True, str, None)
+  host (optional, str, None)
     IPv4 or IPv6 address or FQDN to send trap messages to.
 
 

--- a/collections/ansible_collections/purestorage/flasharray/galaxy.yml
+++ b/collections/ansible_collections/purestorage/flasharray/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purestorage
 name: flasharray
-version: 1.2.0
+version: 1.2.1
 readme: README.md
 authors:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_snmp.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_snmp.py
@@ -53,7 +53,6 @@ options:
     type: str
     description:
     - IPv4 or IPv6 address or FQDN to send trap messages to.
-    required: True
   user:
     type: str
     description:
@@ -218,7 +217,6 @@ def create_manager(module, array):
                                           version=module.params['version'],
                                           community=module.params['community'],
                                           notification=module.params['notification'],
-                                          user=module.params['user'],
                                           host=module.params['host']
                                           )
             except Exception:
@@ -281,7 +279,7 @@ def main():
     argument_spec = purefa_argument_spec()
     argument_spec.update(dict(
         name=dict(type='str', required=True),
-        host=dict(type='str', required=True),
+        host=dict(type='str'),
         state=dict(type='str', default='present', choices=['absent', 'present']),
         user=dict(type='str'),
         notification=dict(type='str', choices=['inform', 'trap'], default='trap'),


### PR DESCRIPTION
##### SUMMARY
When deleting an SNMP Manager the `host` parameter was set as mandatory, when in fact it is not actually required.
This removes the required flag from the parameter to make deletes cleaner.
It has no effect on creating a new SNMP manager or updating an existing one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_snmp