### PR TITLE
Teaser for Purity 6 info

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
@@ -418,6 +418,7 @@ SAN_REQUIRED_API_VERSION = '1.10'
 NVME_API_VERSION = '1.16'
 PREFERRED_API_VERSION = '1.15'
 P53_API_VERSION = '1.17'
+P6_API_VERSION = '1.19'
 
 
 def generate_default_dict(array):
@@ -583,6 +584,8 @@ def generate_capacity_dict(array):
         capacity_info['snapshot_space'] = capacity[0]['snapshots']
         capacity_info['thin_provisioning'] = capacity[0]['thin_provisioning']
         capacity_info['total_reduction'] = capacity[0]['total_reduction']
+        if P6_API_VERSION in api_version:
+            capacity_info['journal_space'] = capacity[0]['journal']
 
     return capacity_info
 


### PR DESCRIPTION
##### SUMMARY
The first of probably many Purity 6 enhancements.
This is real simple one to show journal space for the array

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py

##### ADDITIONAL INFORMATION
Note that you won't be able to test this until we get an array running 6 and the RESK SDK for 1.19, but preempting this is easy for this single line item.