### PR TITLE
Add special case for Test Drive VM

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/galaxy.yml
+++ b/collections/ansible_collections/purestorage/flasharray/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purestorage
 name: flasharray
-version: 1.2.1
+version: 1.2.2
 readme: README.md
 authors:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_host.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_host.py
@@ -234,13 +234,7 @@ NVME_API_VERSION = '1.16'
 
 def _is_cbs(array, is_cbs=False):
     """Is the selected array a Cloud Block Store"""
-    model = ''
-    ct0_model = array.get_hardware('CT0')['model']
-    if ct0_model:
-        model = ct0_model
-    else:
-        ct1_model = array.get_hardware('CT1')['model']
-        model = ct1_model
+    model = array.get(controllers=True)[0]['model']
     if 'CBS' in model:
         is_cbs = True
     return is_cbs


### PR DESCRIPTION
##### SUMMARY
If using Pure Storage Test Drive the VM used for the FlashArray doesn't have a CT1 controller and also return 'None' for the hardware model from CT0.

Use a better way to get the array model name which doesn't require iterating through the controllers.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_host.py 
