### PR TITLE
Ensure hosts are lowercase to stop case inconsistency

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/galaxy.yml
+++ b/collections/ansible_collections/purestorage/flasharray/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purestorage
 name: flasharray
-version: 1.2.2
+version: 1.2.3
 readme: README.md
 authors:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_hg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_hg.py
@@ -251,6 +251,8 @@ def main():
 
     state = module.params['state']
     array = get_system(module)
+    new_hosts = [host.lower() for host in module.params['host']]
+    module.params['host'] = new_hosts
     hostgroup = get_hostgroup(module, array)
 
     if module.params['host']:

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_host.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_host.py
@@ -572,6 +572,7 @@ def main():
     module = AnsibleModule(argument_spec, supports_check_mode=True, required_together=required_together)
 
     array = get_system(module)
+    module.params['name'] = module.params['name'].lower()
     pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$")
     if not pattern.match(module.params['name']):
         module.fail_json(msg='Host name {0} does not conform to naming convention'.format(module.params['name']))

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_offload.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_offload.py
@@ -287,7 +287,7 @@ def main():
            len(module.params['bucket']) > 63:
             module.fail_json(msg='Bucket name invalid. '
                                  'Bucket name must be between 3 and 63 characters '
-                                 '(ilowercase, alphanumeric, dash or period) in length '
+                                 '(lowercase, alphanumeric, dash or period) in length '
                                  'and begin and end with a letter or number.')
 
     apps = array.list_apps()

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
@@ -462,6 +462,8 @@ def main():
                            supports_check_mode=False)
 
     state = module.params['state']
+    new_hosts = [host.lower() for host in module.params['host']]
+    module.params['host'] = new_hosts
     array = get_system(module)
     api_version = array._list_available_rest_versions()
     if ":" in module.params['pgroup'] and OFFLOAD_API_VERSION not in api_version:


### PR DESCRIPTION
##### SUMMARY
Ensure all hostnames are lowercase to stop errors with pre-created FA hosts having a mismatch with the true host name.

Example: 
host = Linux
array object = linux

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_host.py
purefa_hg.py
purefa_pg.py

#### ADDITIONAL INFORMATION
Fix a small typo and bump the Collection version number