### PR TITLE
Assume gateway could be empty in pure

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
@@ -171,15 +171,15 @@ def update_interface(module, array, interface):
             try:
                 if new_state['gateway'] is not None:
                     array.set_network_interface(interface['name'],
-                                            address=new_state['address'],
-                                            mtu=new_state['mtu'],
-                                            netmask=new_state['netmask'],
-                                            gateway=new_state['gateway'])
-                else:    
+                                                address=new_state['address'],
+                                                mtu=new_state['mtu'],
+                                                netmask=new_state['netmask'],
+                                                gateway=new_state['gateway'])
+                else:
                     array.set_network_interface(interface['name'],
-                                            address=new_state['address'],
-                                            mtu=new_state['mtu'],
-                                            netmask=new_state['netmask'])
+                                                address=new_state['address'],
+                                                mtu=new_state['mtu'],
+                                                netmask=new_state['netmask'])
             except Exception:
                 module.fail_json(msg="Failed to change settings for interface {0}.".format(interface['name']))
         if not interface['enabled'] and module.params['state'] == 'present':

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
@@ -137,7 +137,7 @@ def update_interface(module, array, interface):
         else:
             if module.params['gateway'] and module.params['gateway'] not in IPNetwork(module.params['address']):
                 module.fail_json(msg='Gateway and subnet are not compatible.')
-            elif not module.params['gateway'] and interface['gateway'] not in IPNetwork(module.params['address']):
+            elif not module.params['gateway'] and interface['gateway'] not in [None, IPNetwork(module.params['address'])]:
                 module.fail_json(msg='Gateway and subnet are not compatible.')
             address = str(module.params['address'].split("/", 1)[0])
         if not module.params['mtu']:
@@ -169,11 +169,17 @@ def update_interface(module, array, interface):
             if 'management' in interface['services'] or 'app' in interface['services'] and address == "0.0.0.0/0":
                 module.fail_json(msg="Removing IP address from a management or app port is not supported")
             try:
-                array.set_network_interface(interface['name'],
+                if new_state['gateway'] is not None:
+                    array.set_network_interface(interface['name'],
                                             address=new_state['address'],
                                             mtu=new_state['mtu'],
                                             netmask=new_state['netmask'],
                                             gateway=new_state['gateway'])
+                else:    
+                    array.set_network_interface(interface['name'],
+                                            address=new_state['address'],
+                                            mtu=new_state['mtu'],
+                                            netmask=new_state['netmask'])
             except Exception:
                 module.fail_json(msg="Failed to change settings for interface {0}.".format(interface['name']))
         if not interface['enabled'] and module.params['state'] == 'present':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Configuring flasharray networking fails when gateway is not setup in pure.

When you don't pass gateway to purefa_network module it will use what's available
in pure device. If this is empty, then it fails. 


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
purefa_network

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
