### PR TITLE
Add support for promotion/demotion of ActiveDR linked pods

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/galaxy.yml
+++ b/collections/ansible_collections/purestorage/flasharray/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purestorage
 name: flasharray
-version: 1.2.8
+version: 1.3.0
 readme: README.md
 authors:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>


### PR DESCRIPTION
##### SUMMARY
With Purity 6 ActiveDR pods that are in a replica link can be promoted and demoted.
Additional options are required for quiescing the pods or recovering from undo pods'
Bump collection version for Purity 6 support

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_pod.py

##### ADDITIONAL INFORMATION
When setting `promote` to `False`, specify the `quiese` boolean. If not specified this will default to `True`
When setting `promote` to `True` specify the `undo` boolean. If not specified this will default to `True`