### PR TITLE
Update case-sensitivity code

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/107_host_case_clarity.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/107_host_case_clarity.yaml
@@ -1,0 +1,7 @@
+minor_changes:
+ - purefa_host - Enforce hostname case-sensitivity rules
+ - purefa_hg - Enforce case-sensitivity rules for hostgroup objects
+ - purefa_pg - Enforce case-sensitivity rules for protection group objects
+
+bugfixes:
+ - purefa_host - Correctly remove host that is in a hostgroup


### PR DESCRIPTION
##### SUMMARY
Update case-sensitivity code
FlashArray hostname/protection group name/hostgroup name rules state that upper case is allowed
Add documentation notes that names are case sensitive but with a note that name uniqueness is NOT case sensitive.
For example: 
    * Allowed hostnames - hosta and hostA
    * However hosta = hostA in a FlashArray

Ensure host that is in a hostgroup can be correctly deleted

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_host
purefa_hg
purefa_pg