### PR TITLE
Ensure module completes without error if re-runinng against an eradicated volume

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/108_fix_eradicate_idempotency.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/108_fix_eradicate_idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefa_volume - Fix failing idempotency on eradicate volume

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_volume.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_volume.py
@@ -693,8 +693,9 @@ def main():
         delete_volume(module, array)
     elif state == 'absent' and destroyed:
         eradicate_volume(module, array)
-    elif state == 'present' and not volume or not size:
-        module.fail_json(msg="Size must be specified to create a new volume")
+    elif state == 'present':
+        if not volume and not size:
+            module.fail_json(msg="Size must be specified to create a new volume")
     elif state == 'absent' and not volume:
         module.exit_json(changed=False)
 


### PR DESCRIPTION
##### SUMMARY
Ensure rerunning a playbook against an eradicated volume doesn't fail

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_volume.py