### PR TITLE
Add support for FA Files in info module

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/109_fa_files_support_purefa_info.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/109_fa_files_support_purefa_info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_info - Add support for FA Files features


### PR DESCRIPTION
##### SUMMARY
Add support for FA Files in Purity//FA v6.0 +
New options added for `gather_subsets`: `clients` `policies` `dir_snaps` and `filesystems`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py