### PR TITLE
Add multi-volume creation support (Purity 6.0+)

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/121_add_multi_volume_creation.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/121_add_multi_volume_creation.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_volume - Add support for multi-volume creation


### PR DESCRIPTION
##### SUMMARY
From Purity 6 we can now create multi-volumes with a single call.

Required information is the number of volumes to create, the index start point and the index character size. Name suffix after index is also supported.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_volume.py

##### ADDITIONAL INFORMATION
New parameters:
 * **count** - Number of volumes to create (Required)
 * **digits** - Size of index string - will pad with zeros where necessary (Default = 1)
 * **start** - Start number for volume index (Default = 0)
 * **suffix** - String to append to volume name and index

The volumes created will have the name format: _name#suffix_ where # is the volume index number

**!! NOTE !!**
 * Only volume creation is supported by multi-volume at this time.
 * If a multi-volume created volume is deleted or eradicated from the sequence he idempotency of the creation task will fail