### PR TITLE
Add multi-host creation support (Purity 6.0+)

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/122_add_multi_host_creation.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/122_add_multi_host_creation.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_host - Add support for multi-host creation


### PR DESCRIPTION
##### SUMMARY
From Purity 6 we can now create multi-hosts with a single call.

Required information is the number of hosts to create, the index start point and the index character size. Name suffix after index is also supported.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_host.py

##### ADDITIONAL INFORMATION
New parameters:
 * **count** - Number of hosts to create (Required)
 * **digits** - Size of index string - will pad with zeros where necessary (Default = 1)
 * **start** - Start number for host index (Default = 0)
 * **suffix** - String to append to host name and index

Optional parameters:
 * **personality** is the only supported optional parameter

The host created will have the name format: _name#suffix_ where # is the host index number

**!! NOTE !!**
 * Only host creation is supported by multi-host at this time.
 * If a multi-host created host is deleted from the sequence the idempotency of the creation task will fail