### PR TITLE
Add multi-vgroup creation support (Purity 6.0+)

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/123_add_multi_vgroup_creation.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/123_add_multi_vgroup_creation.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_vg - Add suppor for multiple vgroup creation


### PR DESCRIPTION
##### SUMMARY
From Purity 6 we can now create multi-volume groups with a single call.

Required information is the number of vgroups to create, the index start point and the index character size. Name suffix after index is also supported.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_vg.py

##### ADDITIONAL INFORMATION
New parameters:
 * **count** - Number of vgroups to create (Required)
 * **digits** - Size of index string - will pad with zeros where necessary (Default = 1)
 * **start** - Start number for vgroups index (Default = 0)
 * **suffix** - String to append to vgroup name and index

The vgroups created will have the name format: _name#suffix_ where # is the vgroup index number

**!! NOTE !!**
 * Only vgroup creation is supported by multi-vgroup at this time.
 * If a multi-vgroup created vgroup is deleted or eradicated from the sequence the idempotency of the creation task will fail