### PR TITLE
Fix pypureclient SDK handshake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install purestorage pycodestyle flake8 py-pure-client
+        pip install purestorage pycodestyle flake8 py-pure-client requests
         pip install ansible-base
     - name: Run pycodestyle
       run: |

--- a/collections/ansible_collections/purestorage/flasharray/README.md
+++ b/collections/ansible_collections/purestorage/flasharray/README.md
@@ -17,6 +17,7 @@ The Pure Storage FlashArray collection consists of the latest versions of the Fl
 - py-pure-client >=v1.8
 - Python >=v2.7
 - netaddr
+- requests
 
 ## Idempotency
 

--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/124_sdk_handshake.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/124_sdk_handshake.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa.py - Resolve issue when pypureclient doesn't handshake array correctly

--- a/collections/ansible_collections/purestorage/flasharray/plugins/doc_fragments/purestorage.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/doc_fragments/purestorage.py
@@ -39,4 +39,5 @@ requirements:
   - purestorage >= 1.19
   - py-pure-client >= 1.6.0
   - netaddr
+  - requests
 '''

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_volume.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_volume.py
@@ -724,7 +724,7 @@ def move_volume(module, array):
             except Exception:
                 vgroup_exists = False
             if target_exists:
-               module.fail_json(msg='Volume of same name already exists in move location')
+                module.fail_json(msg='Volume of same name already exists in move location')
             if pod_exists and vgroup_exists:
                 module.fail_json(msg='Move location {0} matches both a pod and a vgroup. Please rename one of these.'.format(module.params['move']))
             if not pod_exists and not vgroup_exists:


### PR DESCRIPTION
##### SUMMARY
`pypureclient` SDK (for REST 2.x) does not handshake the array to get the latest supported REST version. Instead, it uses the latest it supports, even if this is higher than the array version supports.

This patch interrogates the array for its latest supported version and forces that for all connections.

Requirements are updated to include `requests`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa.py