### PR TITLE
Add Directory Service Update for Purity 6 and Data DS

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/131_add_v6_ds_update.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/131_add_v6_ds_update.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_ds - Add Purity v6 support for Directory Services, including Data DS and updating services


### PR DESCRIPTION
##### SUMMARY
Enhance Directory Service support:
- Add support for FA-Files Data directory Service (Purity v6.0 +)
- Add support for updating Purity//FA 6.0+ Directory Services - still no update feature for Purity 5.x Directory Service)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_ds.py