### PR TITLE
Add support for FC-based array replication

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/132_fc_replication.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/132_fc_replication.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_connect - Add support for FC-based array replication


### PR DESCRIPTION
##### SUMMARY
Add support for FC-based array replication.
From Purity//FA 6.1
All GA caveats must be adhered to.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_connect.py