### PR TITLE
Ignore NTP configuration for CBS arrays

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/135_no_cbs_ntp.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/135_no_cbs_ntp.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_ntp - Ignore NTP configuration for CBS-based arrays

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_ntp.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_ntp.py
@@ -67,6 +67,13 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import get_system, purefa_argument_spec
 
 
+def _is_cbs(array, is_cbs=False):
+    """Is the selected array a Cloud Block Store"""
+    model = array.get(controllers=True)[0]['model']
+    is_cbs = bool('CBS' in model)
+    return is_cbs
+
+
 def remove(duplicate):
     final_list = []
     for num in duplicate:
@@ -114,6 +121,9 @@ def main():
                            supports_check_mode=True)
 
     array = get_system(module)
+    if _is_cbs(array):
+        module.warn('NTP settings are not necessary for a CBS array - ignoring...')
+        module.exit_json(changed=False)
 
     if module.params['state'] == 'absent':
         delete_ntp(module, array)


### PR DESCRIPTION
##### SUMMARY
Setting NTP is irrelevant for CBS-based arrays. Check is the array is CBS and if so give warning message and exit

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_ntp.py