### PR TITLE
Add/Update regex check for pgsnap and snap suffix name

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/137_pgsnap_regex.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/137_pgsnap_regex.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+ - purefa_pgsnap - Add check to ensure suffix name meets naming conventions
+ - purefa_snap - Update suffix regex pattern

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
@@ -146,6 +146,7 @@ EXAMPLES = r'''
 RETURN = r'''
 '''
 
+import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import get_system, purefa_argument_spec
 
@@ -321,10 +322,13 @@ def main():
     module = AnsibleModule(argument_spec,
                            required_if=required_if,
                            supports_check_mode=True)
-
+    pattern = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
     if module.params['suffix'] is None:
         suffix = "snap-" + str((datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds())
         module.params['suffix'] = suffix.replace(".", "")
+    else:
+        if not pattern.match(module.params['suffix']):
+            module.fail_json(msg='Suffix name {0} does not conform to suffix name rules'.format(module.params['suffix']))
 
     if not module.params['target'] and module.params['restore']:
         module.params['target'] = module.params['restore']

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_snap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_snap.py
@@ -225,7 +225,7 @@ def main():
         suffix = "snap-" + str((datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds())
         module.params['suffix'] = suffix.replace(".", "")
     else:
-        pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+        pattern = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
         if not pattern.match(module.params['suffix']):
             module.fail_json(msg='Suffix name {0} does not conform to suffix name rules'.format(module.params['suffix']))
 


### PR DESCRIPTION
##### SUMMARY
pgsnap module not doing a regex check on the suffix parameter to ensure that the provided string conforms to the 
naming convention rules.
Add regex check to code
Update volume snapshot suffix regex pattern to match pgsnap pattern

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py
purefa_snap.py