### PR TITLE
Add support volume restore for volumes in AC based PGs

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/139_pgsnap_ac_support.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/139_pgsnap_ac_support.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pgsnap - Ensure pgsnap restores work for AC PGs


### PR DESCRIPTION
##### SUMMARY
Ensure volume snapshots in AC PGs can be recovered.
``target`` parameter can be a local volume name, or a volume in a pod, eg ``volume2``, or ``pod::volume2``.
If you want the restore to go to a volume in the same AC pod, the od name must still be specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py