### PR TITLE
Case checking for pod names, including filter down to hgroups

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/140_pod_case.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/140_pod_case.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+ - purefa_pod - Ensure all pod names are lowercase for consistency
+ - purefa_hg - Ensure all hostname chacks are lowercase for consistency

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_hg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_hg.py
@@ -173,7 +173,7 @@ def update_hostgroup(module, array):
                         module.fail_json(msg='Failed to add host(s) to hostgroup')
             if module.params['volume']:
                 if volumes:
-                    current_vols = [vol['vol'] for vol in volumes]
+                    current_vols = [vol['vol'].lower() for vol in volumes]
                     cased_vols = [vol.lower() for vol in module.params['volume']]
                     new_volumes = list(set(cased_vols).difference(set(current_vols)))
                     if len(new_volumes) == 1 and module.params['lun']:

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pod.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pod.py
@@ -427,6 +427,8 @@ def main():
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
+    module.params['name'] = module.params['name'].lower()
+
     state = module.params['state']
     array = get_system(module)
 


### PR DESCRIPTION
##### SUMMARY
Enforce all pod names to be lowercase, as there is no case sensitivity in Purity.
If an uppercase name has been manually created, ensure we convert to lowercase when doing checks
adding pod-based volumes to hostgroups
 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pod.py
purefa_hg.py