### PR TITLE
Add support for naming syslog servers with Purity//FA 6.1

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/153_syslog_update.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/153_syslog_update.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_syslog - Add support for naming SYSLOG servers for Purity//FA 6.1 or higher


### PR DESCRIPTION
##### SUMMARY
Add support for naming syslog server entry.
Only available from Purity//FA 6.1 and higher.
Fix idempotency issue for delete.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_syslog.py