### PR TITLE
Add requirements file at Ansible's request

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/requirements.txt
+++ b/collections/ansible_collections/purestorage/flasharray/requirements.txt
@@ -1,0 +1,5 @@
+purestorage >= '1.19'
+py-pure-client >= '1.11'
+netaddr
+requests
+python >= '3.3'


### PR DESCRIPTION
##### SUMMARY
For Ansible 2.11 requirements files are required.
This change was requested by Red Hat.
