### PR TITLE
Add support for renaming protection groups

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/160_rename_pg.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/160_rename_pg.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_pg - Add support to rename protection groups


### PR DESCRIPTION
##### SUMMARY
Add `rename` option to allow rename of existing protection groups.
If the source PG is in a container such as a pod or volume group, eg `pod::pg` or `vg:pg`, then there's no
requirement to specify the container in the `rename` parameter.
Protection Groups cannot be renamed into different containers.

Also add in naming convention check for protection group name as part of create or rename PG

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_pg.py