### PR TITLE
Fix missing pg snapshot info for local snapshots

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/162_pgsnap_info_fix.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/162_pgsnap_info_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_info - Fix missing protection group snapshot info for local snapshots

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
@@ -1100,23 +1100,23 @@ def generate_pgroups_dict(array):
             pgroups_info[protgroup]["days"] = prot_reten["days"]
             pgroups_info[protgroup]["all_for"] = prot_reten["all_for"]
             pgroups_info[protgroup]["target_all_for"] = prot_reten["target_all_for"]
-        if ":" in protgroup:
-            snap_transfers = array.get_pgroup(protgroup, snap=True, transfer=True)
-            pgroups_info[protgroup]["snaps"] = {}
-            for snap_transfer in range(0, len(snap_transfers)):
-                snap = snap_transfers[snap_transfer]["name"]
-                pgroups_info[protgroup]["snaps"][snap] = {
-                    "created": snap_transfers[snap_transfer]["created"],
-                    "started": snap_transfers[snap_transfer]["started"],
-                    "completed": snap_transfers[snap_transfer]["completed"],
-                    "physical_bytes_written": snap_transfers[snap_transfer][
-                        "physical_bytes_written"
-                    ],
-                    "data_transferred": snap_transfers[snap_transfer][
-                        "data_transferred"
-                    ],
-                    "progress": snap_transfers[snap_transfer]["progress"],
-                }
+        snap_transfers = array.get_pgroup(
+            protgroup, snap=True, transfer=True, pending=True
+        )
+        pgroups_info[protgroup]["snaps"] = {}
+        for snap_transfer in range(0, len(snap_transfers)):
+            snap = snap_transfers[snap_transfer]["name"]
+            pgroups_info[protgroup]["snaps"][snap] = {
+                "time_remaining": snap_transfers[snap_transfer]["time_remaining"],
+                "created": snap_transfers[snap_transfer]["created"],
+                "started": snap_transfers[snap_transfer]["started"],
+                "completed": snap_transfers[snap_transfer]["completed"],
+                "physical_bytes_written": snap_transfers[snap_transfer][
+                    "physical_bytes_written"
+                ],
+                "data_transferred": snap_transfers[snap_transfer]["data_transferred"],
+                "progress": snap_transfers[snap_transfer]["progress"],
+            }
     return pgroups_info
 
 


### PR DESCRIPTION
##### SUMMARY
Snapshot information for local protection group snapshots was not showing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py