### PR TITLE
Add no_log to arguments as required

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_apiclient.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_apiclient.py
@@ -212,7 +212,7 @@ def main():
                 choices=["readonly", "ops_admin", "storage_admin", "array_admin"],
             ),
             public_key=dict(type="str", no_log=True),
-            token_ttl=dict(type="int", default=86400),
+            token_ttl=dict(type="int", default=86400, no_log=False),
             issuer=dict(type="str"),
         )
     )

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_offload.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_offload.py
@@ -324,7 +324,7 @@ def main():
             ),
             name=dict(type="str", required=True),
             initialize=dict(default=True, type="bool"),
-            access_key=dict(type="str"),
+            access_key=dict(type="str", no_log=False),
             secret=dict(type="str", no_log=True),
             bucket=dict(type="str"),
             container=dict(type="str", default="offload"),


### PR DESCRIPTION
##### SUMMARY
Ansible 2.11 requires some arguments it thinks might be secure to have a `no_log` option defined.
Add `no_log=False` to required arguments

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_apiclinet.py
purefa_offlad.py