### PR TITLE
Release 1.7.0

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/CHANGELOG.rst
+++ b/collections/ansible_collections/purestorage/flasharray/CHANGELOG.rst
@@ -5,6 +5,30 @@ Purestorage.Flasharray Release Notes
 .. contents:: Topics
 
 
+v1.7.0
+======
+
+Minor Changes
+-------------
+
+- purefa_maintenance - New module to set maintenance windows
+- purefa_pg - Add support to rename protection groups
+- purefa_syslog - Add support for naming SYSLOG servers for Purity//FA 6.1 or higher
+
+Bugfixes
+--------
+
+- purefa_info - Fix missing protection group snapshot info for local snapshots
+- purefa_info - Resolve crash when an offload target is offline
+- purefa_pgsnap - Ensure suffix rules only implemented for state=present
+- purefa_user - Do not allow role changed for breakglass user (pureuser)
+- purefa_user - Do not change role for existing user unless requested
+
+New Modules
+-----------
+
+- purestorage.flasharray.purefa_maintenance - Configure Pure Storage FlashArray Maintence Windows
+
 v1.6.2
 ======
 

--- a/collections/ansible_collections/purestorage/flasharray/changelogs/.plugin-cache.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/.plugin-cache.yaml
@@ -98,6 +98,11 @@ plugins:
       name: purefa_inventory
       namespace: ''
       version_added: 1.0.0
+    purefa_maintenance:
+      description: Configure Pure Storage FlashArray Maintence Windows
+      name: purefa_maintenance
+      namespace: ''
+      version_added: 1.7.0
     purefa_network:
       description: Manage network interfaces in a Pure Storage FlashArray
       name: purefa_network
@@ -228,4 +233,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 1.6.2
+version: 1.7.0

--- a/collections/ansible_collections/purestorage/flasharray/changelogs/changelog.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/changelog.yaml
@@ -150,3 +150,29 @@ releases:
     fragments:
     - 149_volumes_demoted_pods_fix.yaml
     release_date: '2021-02-04'
+  1.7.0:
+    changes:
+      bugfixes:
+      - purefa_info - Fix missing protection group snapshot info for local snapshots
+      - purefa_info - Resolve crash when an offload target is offline
+      - purefa_pgsnap - Ensure suffix rules only implemented for state=present
+      - purefa_user - Do not allow role changed for breakglass user (pureuser)
+      - purefa_user - Do not change role for existing user unless requested
+      minor_changes:
+      - purefa_maintenance - New module to set maintenance windows
+      - purefa_pg - Add support to rename protection groups
+      - purefa_syslog - Add support for naming SYSLOG servers for Purity//FA 6.1 or
+        higher
+    fragments:
+    - 152_fix_user.yaml
+    - 153_syslog_update.yaml
+    - 156_snap_suffix_fix.yaml
+    - 160_rename_pg.yaml
+    - 161_offline_offload_fix.yaml
+    - 162_pgsnap_info_fix.yaml
+    - 163_add_maintenance_windows.yaml
+    modules:
+    - description: Configure Pure Storage FlashArray Maintence Windows
+      name: purefa_maintenance
+      namespace: ''
+    release_date: '2021-03-30'

--- a/collections/ansible_collections/purestorage/flasharray/galaxy.yml
+++ b/collections/ansible_collections/purestorage/flasharray/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purestorage
 name: flasharray
-version: 1.6.2
+version: 1.7.0
 readme: README.md
 authors:
 - Pure Storage Ansible Team <pure-ansible-team@purestorage.com>


### PR DESCRIPTION
##### SUMMARY
Release 1.7.0
=========

Minor Changes
-------------

- purefa_maintenance - New module to set maintenance windows
- purefa_pg - Add support to rename protection groups
- purefa_syslog - Add support for naming SYSLOG servers for Purity//FA 6.1 or higher

Bugfixes
--------

- purefa_info - Fix missing protection group snapshot info for local snapshots
- purefa_info - Resolve crash when an offload target is offline
- purefa_pgsnap - Ensure suffix rules only implemented for state=present
- purefa_user - Do not allow role changed for breakglass user (pureuser)
- purefa_user - Do not change role for existing user unless requested

New Modules
-----------

- purestorage.flasharray.purefa_maintenance - Configure Pure Storage FlashArray Maintence Windows
