### PR TITLE
Ensure dsrole doesn't report true for None or null

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/168_dsrole_fix.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/168_dsrole_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_dsrole - If using None for group or group_base incorrect change state applied

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_dsrole.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_dsrole.py
@@ -140,20 +140,22 @@ def delete_role(module, array):
 
 def create_role(module, array):
     """Create Directory Service Role"""
-    changed = True
-    if not module.check_mode:
-        try:
-            array.set_directory_service_roles(
-                names=[module.params["role"]],
-                group_base=module.params["group_base"],
-                group=module.params["group"],
-            )
-        except Exception:
-            module.fail_json(
-                msg="Create Directory Service Role {0} failed".format(
-                    module.params["role"]
+    changed = False
+    if not module.params["group"] == "" or not module.params["group_base"] == "":
+        changed = True
+        if not module.check_mode:
+            try:
+                array.set_directory_service_roles(
+                    names=[module.params["role"]],
+                    group_base=module.params["group_base"],
+                    group=module.params["group"],
                 )
-            )
+            except Exception:
+                module.fail_json(
+                    msg="Create Directory Service Role {0} failed".format(
+                        module.params["role"]
+                    )
+                )
     module.exit_json(changed=changed)
 
 


### PR DESCRIPTION
##### SUMMARY
setting `group` or `group_base` to `None` or `null` resulted in a create attempt for a role to report a change incorrectly

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_dsrole.py