### PR TITLE
Add new failure state if restoring to stretched pod

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/170_pgsnap_stretch_pod_fail.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/170_pgsnap_stretch_pod_fail.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pgsnap - Fail with warning if trying to restore to a stretched ActiveCluster pod

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
@@ -308,6 +308,10 @@ def restore_pgsnapvolume(module, array):
             + "."
             + module.params["restore"]
         )
+        if "::" in module.params["target"]:
+            pod_name = module.params["target"].split(":")[0]
+            if len(array.get_pod(pod_name, mediator=True)["arrays"] > 1):
+                module.fail_json(msg="Volume cannot be restored to a stretched pod")
         try:
             array.copy_volume(
                 volume, module.params["target"], overwrite=module.params["overwrite"]


### PR DESCRIPTION
##### SUMMARY
If `target` is in a stretched ActiveCluster pod then fail with "nice" message

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py