### PR TITLE
Allow gateway to be None for network port configuration

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/174_null_gateway.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/174_null_gateway.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_network - Allow gateway paremeter to be set as None - needed for non-routing iSCSI ports

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
@@ -145,15 +145,16 @@ def update_interface(module, array, interface):
         if not module.params["address"]:
             address = interface["address"]
         else:
-            if module.params["gateway"] and module.params["gateway"] not in IPNetwork(
-                module.params["address"]
-            ):
-                module.fail_json(msg="Gateway and subnet are not compatible.")
-            elif not module.params["gateway"] and interface["gateway"] not in [
-                None,
-                IPNetwork(module.params["address"]),
-            ]:
-                module.fail_json(msg="Gateway and subnet are not compatible.")
+            if module.params["gateway"]:
+                if module.params["gateway"] and module.params[
+                    "gateway"
+                ] not in IPNetwork(module.params["address"]):
+                    module.fail_json(msg="Gateway and subnet are not compatible.")
+                elif not module.params["gateway"] and interface["gateway"] not in [
+                    None,
+                    IPNetwork(module.params["address"]),
+                ]:
+                    module.fail_json(msg="Gateway and subnet are not compatible.")
             address = str(module.params["address"].split("/", 1)[0])
         if not module.params["mtu"]:
             mtu = interface["mtu"]


### PR DESCRIPTION
##### SUMMARY
iSCSI ports sometimes do not require a gateway address. 
Ensure that if no gateway address is specified then this is accepted as valid.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_network.py