### PR TITLE
Ensure API version supports promoted_status field for pods

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/176_fix_promote_api_issue.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/176_fix_promote_api_issue.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_volume - Ensure REST version is high enough to support promotion_status


### PR DESCRIPTION
##### SUMMARY
Bug introduced in Collections 1.6.2 where `promotion_status` is checked without ensuring the correct REST API version is on the array being called.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_volume.py