### PR TITLE
Add NAA info to volume response dict

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/206_add_naa_info.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/206_add_naa_info.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_volume - Add volume Page 83 NAA information to response dict
+ - purefa_info - Add volume Page 83 NAA information for volume details

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
@@ -447,6 +447,7 @@ V6_MINIMUM_API_VERSION = "2.2"
 FILES_API_VERSION = "2.3"
 FC_REPL_API_VERSION = "2.4"
 ENCRYPTION_STATUS_API_VERSION = "2.6"
+PURE_OUI = "naa.624a9370"
 
 
 def generate_default_dict(module, array):
@@ -951,6 +952,7 @@ def generate_del_vol_dict(array):
             "source": vols[vol]["source"],
             "created": vols[vol]["created"],
             "serial": vols[vol]["serial"],
+            "page83_naa": PURE_OUI + vols[vol]["serial"],
             "time_remaining": vols[vol]["time_remaining"],
             "tags": [],
         }
@@ -979,6 +981,7 @@ def generate_vol_dict(array):
             "source": vols[vol]["source"],
             "size": vols[vol]["size"],
             "serial": vols[vol]["serial"],
+            "page83_naa": PURE_OUI + vols[vol]["serial"],
             "tags": [],
             "hosts": [],
             "bandwidth": "",
@@ -1000,6 +1003,7 @@ def generate_vol_dict(array):
                 "protocol_endpoint": True,
                 "source": vvols[vvol]["source"],
                 "serial": vvols[vvol]["serial"],
+                "page83_naa": PURE_OUI + vvols[vvol]["serial"],
                 "tags": [],
                 "hosts": [],
             }

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_volume.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_volume.py
@@ -235,6 +235,10 @@ volume:
             description: Volume serial number
             type: str
             sample: '361019ECACE43D83000120A4'
+        page83_naa:
+            description: Volume NAA canonical name
+            type: str
+            sample: 'naa.624a9370361019ecace43db3000120a4'
         created:
             description: Volume creation time
             type: str
@@ -277,6 +281,7 @@ OFFLOAD_API_VERSION = "1.16"
 IOPS_API_VERSION = "1.17"
 MULTI_VOLUME_VERSION = "2.2"
 PROMOTE_API_VERSION = "1.19"
+PURE_OUI = "naa.624a9370"
 
 
 def get_pod(module, array):
@@ -528,6 +533,9 @@ def create_volume(module, array):
                                     module.params["size"],
                                     bandwidth_limit=module.params["bw_qos"],
                                 )
+                                volfact["page83_naa"] = (
+                                    PURE_OUI + volfact["serial"].lower()
+                                )
                             except Exception:
                                 module.fail_json(
                                     msg="Volume {0} creation failed.".format(
@@ -551,6 +559,9 @@ def create_volume(module, array):
                                     module.params["name"],
                                     module.params["size"],
                                     iops_limit=module.params["iops_qos"],
+                                )
+                                volfact["page83_naa"] = (
+                                    PURE_OUI + volfact["serial"].lower()
                                 )
                             except Exception:
                                 module.fail_json(
@@ -576,6 +587,9 @@ def create_volume(module, array):
                                     iops_limit=module.params["iops_qos"],
                                     bandwidth_limit=module.params["bw_qos"],
                                 )
+                                volfact["page83_naa"] = (
+                                    PURE_OUI + volfact["serial"].lower()
+                                )
                             except Exception:
                                 module.fail_json(
                                     msg="Volume {0} creation failed.".format(
@@ -597,6 +611,9 @@ def create_volume(module, array):
                                     module.params["size"],
                                     bandwidth_limit=module.params["bw_qos"],
                                 )
+                                volfact["page83_naa"] = (
+                                    PURE_OUI + volfact["serial"].lower()
+                                )
                             except Exception:
                                 module.fail_json(
                                     msg="Volume {0} creation failed.".format(
@@ -614,6 +631,7 @@ def create_volume(module, array):
                             volfact = array.create_volume(
                                 module.params["name"], module.params["size"]
                             )
+                            volfact["page83_naa"] = PURE_OUI + volfact["serial"].lower()
                         except Exception:
                             module.fail_json(
                                 msg="Volume {0} creation failed.".format(
@@ -625,6 +643,7 @@ def create_volume(module, array):
                 volfact = array.create_volume(
                     module.params["name"], module.params["size"]
                 )
+                volfact["page83_naa"] = PURE_OUI + volfact["serial"].lower()
             except Exception:
                 module.fail_json(
                     msg="Volume {0} creation failed.".format(module.params["name"])
@@ -734,6 +753,7 @@ def create_multi_volume(module, array):
                     "created": time.strftime(
                         "%Y-%m-%d %H:%M:%S", time.localtime(temp[count].created / 1000)
                     ),
+                    "page83_naa": PURE_OUI + temp[count].serial.lower(),
                 }
                 if bw_qos_size != 0:
                     volfact[vol_name]["bandwidth_limit"] = temp[
@@ -769,6 +789,7 @@ def copy_from_volume(module, array):
                 volfact = array.copy_volume(
                     module.params["name"], module.params["target"]
                 )
+                volfact["page83_naa"] = PURE_OUI + volfact["serial"].lower()
                 changed = True
             except Exception:
                 module.fail_json(
@@ -783,6 +804,7 @@ def copy_from_volume(module, array):
                     module.params["target"],
                     overwrite=module.params["overwrite"],
                 )
+                volfact["page83_naa"] = PURE_OUI + volfact["serial"].lower()
                 changed = True
             except Exception:
                 module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Add Page 83 NAA name to volume creation response dict as value `page83_naa`
Add Page 83 NAA info to volume details in info module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_volume.py
purefa_info.py

##### ADDITIONAL INFORMATION
Using `purefa_volume` gives a new response dict that looks like this:
```
    "volume": {
        "created": "2021-06-14T14:27:55Z",
        "name": "simon_naa",
        "page83_naa": "naa.624a9370F269A91400C5408F0001A0B2",
        "promotion_status": "promoted",
        "requested_promotion_state": "promoted",
        "serial": "F269A91400C5408F0001A0B2",
        "size": 10737418240,
        "source": null
    }
```
This is exposed during volume creation, either new or cloning from an existing volume.