### PR TITLE
Add support for FA-Files Directory Quotas

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/208_add_directory_quota_support.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/208_add_directory_quota_support.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_policy - Add support for FA-files Directory Quotas and associated rules and members
+ - purefa_info - Add high-level count for directory quotas and details for all FA-Files policies


### PR DESCRIPTION
##### SUMMARY
Add support for FA-Files directory quotas.
Control of attached members and quota rules is included
Add high level count of directory quotas
Add details for all FA-Files policies

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_policy.py
purefa_info.py

##### ADDITIONAL INFORMATION
Requires FA-Files enabled and Purity//FA 6.1.7 or higher