### PR TITLE
Add join_ou option to purefa_ds

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/214_join_ou.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/214_join_ou.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_ds - Add ``join_ou`` parameter for AD account creation

--- a/collections/ansible_collections/purestorage/flasharray/requirements.txt
+++ b/collections/ansible_collections/purestorage/flasharray/requirements.txt
@@ -1,5 +1,5 @@
 purestorage >= '1.19'
-py-pure-client >= '1.14'
+py-pure-client >= '1.16'
 netaddr
 requests
 python >= '3.3'


### PR DESCRIPTION
##### SUMMARY
Add `join_ou` parameter.
Requires REST 2.8 (Purity//FA 6.1.8 or higher)
Bump min py-pure-client version

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_ad.py
requirements.txt