### PR TITLE
Deprecate protocol parameter for host module

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/226_deprecate_protocol.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/226_deprecate_protocol.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_host - Deprecate ``protocol`` parameter. No longer required.


### PR DESCRIPTION
##### SUMMARY
`protocol` parameter is no longer required. Deprecated from Collection 1.11 and will be removed in Collection 1.13.
Retain parameter for backwards compatibility, but it actually does nothing.
Remove from all documentation examples.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_host.py