### PR TITLE
Add directory snapshot rename support

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/README.md
+++ b/collections/ansible_collections/purestorage/flasharray/README.md
@@ -14,7 +14,7 @@ The Pure Storage FlashArray collection consists of the latest versions of the Fl
     - some modules require higher versions of Purity
 - Some modules require specific Purity versions
 - purestorage >=v1.19
-- py-pure-client >=v1.14
+- py-pure-client >=v1.19
 - Python >=v2.7
 - netaddr
 - requests

--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/238_add_dirsnap_rename.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/238_add_dirsnap_rename.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_dirsnap - Add support to rename directory snapshots not managed by a snapshot policy

--- a/collections/ansible_collections/purestorage/flasharray/requirements.txt
+++ b/collections/ansible_collections/purestorage/flasharray/requirements.txt
@@ -1,5 +1,5 @@
 purestorage >= '1.19'
-py-pure-client >= '1.18'
+py-pure-client >= '1.19'
 netaddr
 requests
 python >= '3.3'


### PR DESCRIPTION
##### SUMMARY
Add support for directory snapshot rename.
Requires Purity//FA 6.2.1 or higher and FA-Files enabled.
Add new parameters:
  `rename`: boolean - default False
  `new_client`: string
  `new_suffix`: string - must conform to suffix naming rules
Remove default value for `keep_for` to allow for rename and retention time changes together.
Add extra check for `keep_for` in the allowed range during snapshot creation.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_dirsnap.py

#### ADDITIONAL INFORMATION
`py-pure-client` minimum requirement changed to `1.19` as a minimum