### PR TITLE
Add multi-offload support

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/242_multi_offload.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/242_multi_offload.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_offload - Add support for multiple, homogeneous, offload targets


### PR DESCRIPTION
##### SUMMARY
Add support for multiple offload targets.
Requires Purity//FA 6.2.3 (REST 2.11).
Limit of targets is 5.
Currently all targets must be of the same type.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_offload.py