### PR TITLE
Fix bug in operator precedence

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/246_python_precedence.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/246_python_precedence.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_network - Resolve bug stopping management IP address being changed correctly

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
@@ -236,10 +236,8 @@ def update_interface(module, array, interface):
     if new_state != current_state:
         changed = True
         if (
-            ("management" in interface["services"]
-            or "app" in interface["services"])
-            and address == "0.0.0.0/0"
-        ):
+            "management" in interface["services"] or "app" in interface["services"]
+        ) and address == "0.0.0.0/0":
             module.fail_json(
                 msg="Removing IP address from a management or app port is not supported"
             )

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
@@ -236,8 +236,8 @@ def update_interface(module, array, interface):
     if new_state != current_state:
         changed = True
         if (
-            "management" in interface["services"]
-            or "app" in interface["services"]
+            ("management" in interface["services"]
+            or "app" in interface["services"])
             and address == "0.0.0.0/0"
         ):
             module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Missing parentheses is causing the setting of management IP addresses to fail.
Python operator precedence is getting confused.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_network.py