### PR TITLE
Add schedule to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,11 @@
 name: Pure Storage Ansible CI
 
-on: [pull_request]
-
+on: 
+  pull_request:
+  # Run CI once per day (at 06:00 UTC)
+  # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test and ansible-core
+  schedule:
+    - cron: '0 6 * * *'
 jobs:
   build:
 


### PR DESCRIPTION
##### SUMMARY
Run CI at 0600 UTC daily to ensure no core changes break our collection