### PR TITLE
Fix quota policies idempotency and add snapshot policy directories

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/268_fix_quotas_issues.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/268_fix_quotas_issues.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+ - purefa_policy - Allow directories in snapshot policies to be managed
+bugfixes:
+ - purefa_policy - Fix idempotency issue with quota policy rules


### PR DESCRIPTION
##### SUMMARY
Bug from #267 where quotas were not idempotent causing additional quotas to be created and enforced quotas to fail even when already existing.

From #266 add missing feature to allow directories to be managed in a snapshot policy.
New example provided for this functionality

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_policy.py