### PR TITLE
distutils deprecated - replace with packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install purestorage pycodestyle flake8 py-pure-client requests
+        pip install purestorage pycodestyle flake8 py-pure-client requests packaging
         pip install ansible-core
     - name: Run pycodestyle
       run: |


### PR DESCRIPTION
##### SUMMARY
PEP632 deprecates `distutils` from Python 3.12, so replace with `packaging`

##### COMPONENT NAME
purefa_offload.py