### PR TITLE
Purepg fixes

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
@@ -730,6 +730,7 @@ def main():
     array = get_system(module)
     pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$")
     if module.params["rename"]:
+        module.params["rename"] = module.params["rename"].lower()
         if not pattern.match(module.params["rename"]):
             module.fail_json(
                 msg="Rename value {0} does not conform to naming convention".format(

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
@@ -730,7 +730,6 @@ def main():
     array = get_system(module)
     pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$")
     if module.params["rename"]:
-        module.params["rename"] = module.params["rename"].lower()
         if not pattern.match(module.params["rename"]):
             module.fail_json(
                 msg="Rename value {0} does not conform to naming convention".format(

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
@@ -615,13 +615,13 @@ def update_pgroup(module, array):
                     rename = container + ":" + module.params["rename"]
             else:
                 rename = module.params["rename"]
-                renamed = True
-                if not module.check_mode:
-                    try:
-                        array.rename_pgroup(module.params["pgroup"], rename)
-                        module.params["pgroup"] = rename
-                    except Exception:
-                        module.fail_json(msg="Rename to {0} failed.".format(rename))
+            renamed = True
+            if not module.check_mode:
+                try:
+                    array.rename_pgroup(module.params["pgroup"], rename)
+                    module.params["pgroup"] = rename
+                except Exception:
+                    module.fail_json(msg="Rename to {0} failed.".format(rename))
         else:
             module.warn(
                 "Rename failed. Protection group {0} already exists in container. Continuing with other changes...".format(

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
@@ -316,8 +316,10 @@ def restore_pgsnapvolume(module, array):
         else:
             source_pod_name = ""
         if source_pod_name != target_pod_name:
-            if (len(array.get_pod(target_pod_name, mediator=True)["arrays"]) > 1) and
-               (POD_SNAPSHOT not in api_version):
+            if (
+                len(array.get_pod(target_pod_name, mediator=True)["arrays"]) > 1
+                and POD_SNAPSHOT not in api_version
+            ):
                 module.fail_json(msg="Volume cannot be restored to a stretched pod")
     if not module.check_mode:
         try:

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
@@ -307,15 +307,6 @@ def restore_pgsnapvolume(module, array):
         + "."
         + module.params["restore"]
     )
-    if "::" in module.params["target"]:
-        target_pod_name = module.params["target"].split(":")[0]
-        if "::" in module.params["name"]:
-            source_pod_name = module.params["name"].split(":")[0]
-        else:
-            source_pod_name = ""
-        if source_pod_name != target_pod_name:
-            if len(array.get_pod(target_pod_name, mediator=True)["arrays"]) > 1:
-                module.fail_json(msg="Volume cannot be restored to a stretched pod")
     if not module.check_mode:
         try:
             array.copy_volume(

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
@@ -171,6 +171,7 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa impo
 from datetime import datetime
 
 OFFLOAD_API = "1.16"
+POD_SNAPSHOT = "2.4"
 
 
 def _check_offload(module, array):
@@ -281,6 +282,7 @@ def create_pgsnapshot(module, array):
 
 def restore_pgsnapvolume(module, array):
     """Restore a Protection Group Snapshot Volume"""
+    api_version = array._list_available_rest_versions()
     changed = True
     if module.params["suffix"] == "latest":
         all_snaps = array.get_pgroup(module.params["name"], snap=True)
@@ -307,6 +309,16 @@ def restore_pgsnapvolume(module, array):
         + "."
         + module.params["restore"]
     )
+    if "::" in module.params["target"]:
+        target_pod_name = module.params["target"].split(":")[0]
+        if "::" in module.params["name"]:
+            source_pod_name = module.params["name"].split(":")[0]
+        else:
+            source_pod_name = ""
+        if source_pod_name != target_pod_name:
+            if (len(array.get_pod(target_pod_name, mediator=True)["arrays"]) > 1) and
+               (POD_SNAPSHOT not in api_version):
+                module.fail_json(msg="Volume cannot be restored to a stretched pod")
     if not module.check_mode:
         try:
             array.copy_volume(


### PR DESCRIPTION
##### SUMMARY
These commits fix some bugs related to usage of protection groups inside of pods.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pg
purefa_pgsnap

##### ADDITIONAL INFORMATION
- purefa_pg
-- renaming of protection groups forced the new name to be lower case
-- renaming of protection groups inside of pods did actually not do anything due to wrong indentation
- purefa_pgsnap
-- restore of snapped volumes to stretched pods was forbidden by code but is allowed in Pure UI since at least 6.1.13, probably even earlier