### PR TITLE
fixed IPv6 netmask handling

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
@@ -204,7 +204,7 @@ def update_interface(module, array, interface):
             ]:
                 module.fail_json(msg="Gateway and subnet are not compatible.")
         address = str(module.params["address"].split("/", 1)[0])
-        ip_version = str(IPAddress(address).version)
+    ip_version = str(IPAddress(address).version)
     if not module.params["mtu"]:
         mtu = interface["mtu"]
     else:

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_network.py
@@ -204,6 +204,7 @@ def update_interface(module, array, interface):
             ]:
                 module.fail_json(msg="Gateway and subnet are not compatible.")
         address = str(module.params["address"].split("/", 1)[0])
+        ip_version = str(IPAddress(address).version)
     if not module.params["mtu"]:
         mtu = interface["mtu"]
     else:
@@ -227,6 +228,8 @@ def update_interface(module, array, interface):
         if module.params["gateway"] not in IPNetwork(full_addr):
             module.fail_json(msg="Gateway and subnet are not compatible.")
         gateway = module.params["gateway"]
+    if ip_version == "6":
+        netmask = str(IPAddress(netmask).netmask_bits())
     new_state = {
         "address": address,
         "mtu": mtu,


### PR DESCRIPTION
Previously setting an IPv6 address resulted in a failure since FlashArray REST API only accepts prefix length for IPv6 addresses.
For legacy IP only decimal subnet notation is accepted, prefix length is not. 
Added a conditional to use prefix length if IPv6 is used and keep default subnet notation for legacy IP.
Since those parameters are passed to py-pure-client the issue could be fixed there aswell.
For now this workaround does it's job