### PR TITLE
Add FileSystem Replication support

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/277_add_fs_repl.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/277_add_fs_repl.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_fs - Add support for replicated file systems


### PR DESCRIPTION
##### SUMMARY
Add support for filesystem replication.
Filesystems can now be created in a pod or moved to/from a pod. 
All standard pod rules still apply.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_fs.py

##### ADDITIONAL INFORMATION
Requires Purity//FA 6.3.0 or higher