### PR TITLE
Add info for PG snapshots and support for PG safemode

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/278_pgsnap_info.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/278_pgsnap_info.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - purefa_info - Add info for protection group snapshots 
+  - purefa_info - Add info for protection group safe mode setting (Requires Purity//FA 6.3.0 or higher)


### PR DESCRIPTION
##### SUMMARY
Add info for protection group snapshots.
Add info for PG level safemode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py

##### ADDITIONAL INFORMATION
PG level safemode info requires Purity//FA 6.3.0 or higher