### PR TITLE
fix: no changed when new_volumes is empty

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_hg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_hg.py
@@ -256,11 +256,11 @@ def update_hostgroup(module, array):
                             )
                         )
                 else:
-                    changed = True
                     for cvol in new_volumes:
                         try:
                             if not module.check_mode:
                                 array.connect_hgroup(current_hostgroup, cvol)
+                            changed = True
                         except Exception:
                             module.fail_json(
                                 msg="Failed to connect volume {0} to hostgroup {1}.".format(
@@ -284,11 +284,11 @@ def update_hostgroup(module, array):
                             )
                         )
                 else:
-                    changed = True
                     for cvol in module.params["volume"]:
                         try:
                             if not module.check_mode:
                                 array.connect_hgroup(current_hostgroup, cvol)
+                            changed = True
                         except Exception:
                             module.fail_json(
                                 msg="Failed to connect volume {0} to hostgroup {1}.".format(


### PR DESCRIPTION
##### SUMMARY
When new_volumes is empty, `changed` should not be set to `true`. This PR is a fix for #289 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- purefa_hg

##### ADDITIONAL INFORMATION
- I did not have the opportunity to test this change because I don't have the hardware to test outside our environment. 

