### PR TITLE
Fix bind password idempotency

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/292_fix_ds_password.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/292_fix_ds_password.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_ds - Add new parameter `force_bind_password` (default = True) to allow idempotency for module

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_ds.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_ds.py
@@ -531,7 +531,7 @@ def main():
             uri=dict(type="list", elements="str"),
             state=dict(type="str", default="present", choices=["absent", "present"]),
             enable=dict(type="bool", default=False),
-            force_bind_password=dict(type="bool", default=True),
+            force_bind_password=dict(type="bool", default=True, no_log=True),
             bind_password=dict(type="str", no_log=True),
             bind_user=dict(type="str"),
             base_dn=dict(type="str"),


### PR DESCRIPTION
##### SUMMARY
Add new parameter `force_bind_password` which defaults to `True`
If the bind user is not changed and `force_bind_password` is set `false` then this allows the
module to be idempotent.
`force_bind_password` is ignored if the bind user is changed and a password is required at this point

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_ds.py