### PR TITLE
Add support for NFS policies user mapping

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/294_user_map_support.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/294_user_map_support.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - purefa_policy - Add support for NFS policy user mapping
+  - purefa_info - Add NFS policy user mapping status

--- a/collections/ansible_collections/purestorage/flasharray/plugins/doc_fragments/purestorage.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/doc_fragments/purestorage.py
@@ -39,7 +39,7 @@ notes:
 requirements:
   - python >= 3.3
   - purestorage >= 1.19
-  - py-pure-client >= 1.22.0
+  - py-pure-client >= 1.26.0
   - netaddr
   - requests
   - pycountry

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
@@ -780,7 +780,7 @@ def generate_dir_snaps_dict(array):
     return dir_snaps_info
 
 
-def generate_policies_dict(array, quota_available):
+def generate_policies_dict(array, quota_available, nfs_user_mapping):
     policy_info = {}
     policies = list(array.get_policies().items)
     for policy in range(0, len(policies)):
@@ -807,6 +807,11 @@ def generate_policies_dict(array, quota_available):
                 }
                 policy_info[p_name]["rules"].append(smb_rules_dict)
         if policies[policy].policy_type == "nfs":
+            if nfs_user_mapping:
+                nfs_policy = list(array.get_policies(names=[p_name]).items)[0]
+                policy_info[p_name][
+                    "user_mapping_enabled"
+                ] = nfs_policy.user_mapping_enabled
             rules = list(
                 array.get_policies_nfs_client_rules(policy_names=[p_name]).items
             )
@@ -2037,11 +2042,15 @@ def main():
         if "filesystems" in subset or "all" in subset:
             info["filesystems"] = generate_filesystems_dict(array_v6)
         if "policies" in subset or "all" in subset:
+            if NFS_USER_MAP_VERSION in api_version:
+                user_map = True
+            else:
+                user_map = False
             if DIR_QUOTA_API_VERSION in api_version:
                 quota = True
             else:
                 quota = False
-            info["policies"] = generate_policies_dict(array_v6, quota)
+            info["policies"] = generate_policies_dict(array_v6, quota, user_map)
         if "clients" in subset or "all" in subset:
             info["clients"] = generate_clients_dict(array_v6)
         if "dir_snaps" in subset or "all" in subset:

--- a/collections/ansible_collections/purestorage/flasharray/requirements.txt
+++ b/collections/ansible_collections/purestorage/flasharray/requirements.txt
@@ -1,5 +1,5 @@
 purestorage >= '1.19'
-py-pure-client >= '1.22'
+py-pure-client >= '1.25'
 netaddr
 requests
 python >= '3.3'


### PR DESCRIPTION
##### SUMMARY
Add support for NFS policies supporting user mapping
Update minimum requirements for py-pure-client to support this
Feature requires Purity//FA 6.3.3

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_policy.py
purefa_info.py

##### ADDITIONAL INFORMATION
Add `user_mapping_enabled` as a new boolean parameter. Default = True