### PR TITLE
Add support for multiple DNS configurations

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/295_multi_dns.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/295_multi_dns.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - purefa_info - Add support for multiple DNS configurations
+  - purefa_dns - Add support for multiple DNS configurations

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_dns.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_dns.py
@@ -22,6 +22,8 @@ short_description: Configure FlashArray DNS settings
 description:
 - Set or erase configuration for the DNS settings.
 - Nameservers provided will overwrite any existing nameservers.
+- From Purity//FA 6.3.3 DNS setting for FA-File can be configured seperately
+  to the management DNS settings
 author:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
@@ -41,6 +43,7 @@ options:
       IPv4 or IPv6 - No validation is done of the addresses is performed.
     type: list
     elements: str
+  service:
 extends_documentation_fragment:
 - purestorage.flasharray.purestorage.fa
 """

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
@@ -464,6 +464,7 @@ PURE_OUI = "naa.624a9370"
 SAFE_MODE_VERSION = "2.10"
 PER_PG_VERSION = "2.13"
 SAML2_VERSION = "2.11"
+NFS_USER_MAP_VERSION = "2.15"
 
 
 def generate_default_dict(module, array):
@@ -595,6 +596,15 @@ def generate_config_dict(module, array):
             "slp_enabled": smi_s.slp_enabled,
             "wbem_https_enabled": smi_s.wbem_https_enabled,
         }
+        if NFS_USER_MAP_VERSION in api_version:
+            config_info["dns"] = {}
+            dns_configs = list(arrayv6.get_dns().items)
+            for config in range(0, len(dns_configs)):
+                config_info["dns"][dns_configs[config].services[0]] = {
+                    "source": dns_configs[config].source.name,
+                    "nameservers": dns_configs[config].nameservers,
+                    "domain": dns_configs[config].domain,
+                }
         if SAML2_VERSION in api_version:
             config_info["saml2sso"] = {}
             saml2 = list(arrayv6.get_sso_saml2_idps().items)


### PR DESCRIPTION
##### SUMMARY
Add support for multiple DNS configurations as provided by Purity//FA 6.3.3 when FA-Files is enabled

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_dns.py
purefa_info.py

##### ADDITIONAL INFORMATION
New parameters `service`, `name` and `source` are added to allow for second DNS config for FA-files service.