### PR TITLE
Fix api_version and retention_lock errors

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
@@ -670,7 +670,7 @@ def update_pgroup(module, array):
                     res = arrayv6.patch_protection_groups(
                         names=[module.params["pgroup"]],
                         protection_group=flasharray.ProtectionGroup(
-                            retention_lock="racheted"
+                            retention_lock="ratcheted"
                         ),
                     )
                 except Exception:
@@ -680,7 +680,7 @@ def update_pgroup(module, array):
                             res.errors[0].message,
                         )
                     )
-        if current_pg.retention_lock == "racheted" and not module.params["safe_mode"]:
+        if current_pg.retention_lock == "ratcheted" and not module.params["safe_mode"]:
             module.warn(
                 "Disabling SafeMode on protection group {0} can only be performed by Pure Technical Support".format(
                     module.params["pgroup"]

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pg.py
@@ -448,8 +448,8 @@ def rename_exists(module, array):
 def update_pgroup(module, array):
     """Update Protection Group"""
     changed = renamed = False
+    api_version = array._list_available_rest_versions()
     if module.params["target"]:
-        api_version = array._list_available_rest_versions()
         connected_targets = []
         connected_arrays = get_arrays(array)
 


### PR DESCRIPTION
##### SUMMARY
In this change there is a fix for use of undefined variable api_version in some cases. Also there is a fix for a typo when using retention_locks on protection groups.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
FlashArray.purefa_pg

##### ADDITIONAL INFORMATION
The bug regarding use of undefined variable api_version occurs when the ansible playbook leads to the python call "update_pgroup" without having a "target" parameter defined.
The bug(fix) regarding retention_locks has not been tested but the typo was noticed during investigation of the prior bug.