### PR TITLE
Add TLS support to AD

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/296_ad_tls.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/296_ad_tls.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_ad - Add support for TLS and joining existing AD account


### PR DESCRIPTION
##### SUMMARY
Add support for TLS and joining existing AD account.
Requires Purity//FA 6.3.3

##### ISSUE TYPE
- Feature Pull Request