### PR TITLE
NTP and DNS Idempotency Support

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/294_dns_ntp_idempotency_absent.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/294_dns_ntp_idempotency_absent.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+ - purefa_dns - Corrects logic where API responds with an empty list rather than a list with a single empty string in it.
+ - purefa_ntp - Corrects workflow so that the state between desired and current are checked before marking the changed flag to true during an absent run

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_dns.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_dns.py
@@ -85,7 +85,9 @@ def delete_dns(module, array):
     """Delete DNS settings"""
     changed = False
     current_dns = array.get_dns()
-    if current_dns["domain"] == "" and current_dns["nameservers"] == [""]:
+    if current_dns["domain"] == "" and (
+        current_dns["nameservers"] == [] or current_dns["nameservers"] == [""]
+    ):
         module.exit_json(changed=changed)
     else:
         try:

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_ntp.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_ntp.py
@@ -90,13 +90,15 @@ def remove(duplicate):
 
 def delete_ntp(module, array):
     """Delete NTP Servers"""
-    changed = True
-    if not module.check_mode:
-        if array.get(ntpserver=True)["ntpserver"] != []:
+    if array.get(ntpserver=True)["ntpserver"] != []:
+        changed = True
+        if not module.check_mode:
             try:
                 array.set(ntpserver=[])
             except Exception:
                 module.fail_json(msg="Deletion of NTP servers failed")
+    else:
+        changed = False
     module.exit_json(changed=changed)
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
During our testing, we have found that the NTP and DNS changes made on `state: absent` are not idempotent.  These attempt to resolve those issues.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

* `purefa_dns`
* `purefa_ntp`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- All new PRs must include a changelog fragment
- Details of naming convention and format can be found [here](https://docs.ansible.com/ansible/latest/community/development_process.html#creating-a-changelog-fragment)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
