### PR TITLE
Add all_squash support

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/317_add_all_squash.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/317_add_all_squash.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_policy - Add ``all_squash``, ``anonuid`` and ``anongid`` to NFS client rules options 


### PR DESCRIPTION
##### SUMMARY
Add `all_squash` support for NFS client policy rules, together with `anonuid` and `anongid`
Requires Purity//FA 6.3.4 or higher

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_policy.py