### PR TITLE
Ensure lockout in seconds

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/319_lockout.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/319_lockout.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_info - Ensure global admin lockout duration is measured in seconds

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
@@ -694,6 +694,10 @@ def generate_config_dict(module, array):
     config_info["scsi_timeout"] = array.get(scsi_timeout=True)["scsi_timeout"]
     if S3_REQUIRED_API_VERSION in api_version:
         config_info["global_admin"] = array.get_global_admin_attributes()
+        if config_info["global_admin"]["lockout_duration"] > 0:
+            config_info["global_admin"]["lockout_duration"] = (
+                config_info["global_admin"]["lockout_duration"] / 1000
+            )
     return config_info
 
 

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_info.py
@@ -695,7 +695,7 @@ def generate_config_dict(module, array):
     if S3_REQUIRED_API_VERSION in api_version:
         config_info["global_admin"] = array.get_global_admin_attributes()
         if config_info["global_admin"]["lockout_duration"] > 0:
-            config_info["global_admin"]["lockout_duration"] = (
+            config_info["global_admin"]["lockout_duration"] = int(
                 config_info["global_admin"]["lockout_duration"] / 1000
             )
     return config_info


### PR DESCRIPTION
##### SUMMARY
Ensure global admin `lockout_duration` is meased in seconds.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py