### PR TITLE
Ensure latest snapshot is complete before using for restore

### DIFF
--- a/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/320_completed_snaps.yaml
+++ b/collections/ansible_collections/purestorage/flasharray/changelogs/fragments/320_completed_snaps.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefa_pgsnap - Resolved intermittent error where `latest` snapshot is not complete and can fail. Only select latest completed snapshot to restore from.

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
@@ -285,7 +285,9 @@ def restore_pgsnapvolume(module, array):
     api_version = array._list_available_rest_versions()
     changed = True
     if module.params["suffix"] == "latest":
-        all_snaps = array.get_pgroup(module.params["name"], snap=True, transfer=True).reverse()
+        all_snaps = array.get_pgroup(
+            module.params["name"], snap=True, transfer=True
+        ).reverse()
         for snap in all_snaps:
             if not snap["completed"]:
                 latest_snap = snap["name"]

--- a/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
+++ b/collections/ansible_collections/purestorage/flasharray/plugins/modules/purefa_pgsnap.py
@@ -285,9 +285,15 @@ def restore_pgsnapvolume(module, array):
     api_version = array._list_available_rest_versions()
     changed = True
     if module.params["suffix"] == "latest":
-        all_snaps = array.get_pgroup(module.params["name"], snap=True)
-        latest_snap = all_snaps[len(all_snaps) - 1]["name"]
-        module.params["suffix"] = latest_snap.split(".")[1]
+        all_snaps = array.get_pgroup(module.params["name"], snap=True, transfer=True).reverse()
+        for snap in all_snaps:
+            if not snap["completed"]:
+                latest_snap = snap["name"]
+                break
+        try:
+            module.params["suffix"] = latest_snap.split(".")[1]
+        except NameError:
+            module.fail_json(msg="There is no completed snapshot available.")
     if ":" in module.params["name"] and "::" not in module.params["name"]:
         if get_rpgsnapshot(module, array) is None:
             module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Snap Restore can fail if the latest snapshot is still in the middle of processing and hasn't completed.
Ensure that when selecting `latest` we get the latest completed snapshot.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py