### PR TITLE
Allow VLAN support for NVMe-RoCE and file interfaces

### DIFF
--- a/changelogs/fragments/330_extend_vlan.yaml
+++ b/changelogs/fragments/330_extend_vlan.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_vlan - Extend VLAN support to cover NVMe-RoCE and file interfaces

--- a/plugins/modules/purefa_vlan.py
+++ b/plugins/modules/purefa_vlan.py
@@ -28,7 +28,8 @@ options:
   name:
     description:
       - Interface name, including controller indentifier.
-      - VLANs are only supported on iSCSI physical interfaces
+      - VLANs are only supported on iSCSI, NVMe-RoCE and file
+        physical interfaces
     required: true
     type: str
   state:
@@ -244,9 +245,9 @@ def main():
         module.fail_json(msg="Invalid subnet specified.")
     if not interface:
         module.fail_json(msg="Invalid interface specified.")
-    if "iscsi" not in interface["services"]:
+    if ("iscsi" or "nvme-roce" or "file") not in interface["services"]:
         module.fail_json(
-            msg="Invalid interface specified - must have the iSCSI service enabled."
+            msg="Invalid interface specified - must have service type of iSCSI, NVMe-RoCE or file enabled."
         )
     if subnet["vlan"]:
         vif_name = module.params["name"] + "." + str(subnet["vlan"])


### PR DESCRIPTION
##### SUMMARY
Extend VLAN tagging support to cover NVMe-RoCE and file

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_vlan.py

##### ADDITIONAL INFORMATION
Extends current coverage from just iSCSI