### PR TITLE
Add servicelist update functionality for network ports

### DIFF
--- a/changelogs/fragments/336_add_servicelist.yaml
+++ b/changelogs/fragments/336_add_servicelist.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_network - Added support for servicelist updates


### PR DESCRIPTION
##### SUMMARY
As identified in #335 servicelist update was not available.
This PR resolves that issue by adding a new parameter `servicelist`.
This is a list of services that replaces the existing services for the specified network port.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_network.py