### PR TITLE
Filter out invalid api versions on get_array

### DIFF
--- a/changelogs/fragments/337_fix_non-prod_versions.yml
+++ b/changelogs/fragments/337_fix_non-prod_versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefa.py - Fix issue in Purity versions numbers that are for development versions

--- a/plugins/module_utils/purefa.py
+++ b/plugins/module_utils/purefa.py
@@ -109,7 +109,9 @@ def get_array(module):
         versions = requests.get(
             "https://" + array_name + "/api/api_version", verify=False
         )
-        valid_versions = [x for x in versions.json()["version"] if not re.search('[a-zA-Z]', x)]
+        valid_versions = [
+            x for x in versions.json()["version"] if not re.search("[a-zA-Z]", x)
+        ]
         api_version = valid_versions[-1]
         if array_name and api:
             system = flasharray.Client(

--- a/plugins/module_utils/purefa.py
+++ b/plugins/module_utils/purefa.py
@@ -52,6 +52,7 @@ except ImportError:
 
 from os import environ
 import platform
+import re
 
 VERSION = 1.4
 USER_AGENT_BASE = "Ansible"
@@ -108,7 +109,8 @@ def get_array(module):
         versions = requests.get(
             "https://" + array_name + "/api/api_version", verify=False
         )
-        api_version = versions.json()["version"][-1]
+        valid_versions = [x for x in versions.json()["version"] if not re.search('[a-zA-Z]', x)]
+        api_version = valid_versions[-1]
         if array_name and api:
             system = flasharray.Client(
                 target=array_name,


### PR DESCRIPTION
##### SUMMARY
Filter out invalid api versions that contain letters from the list of api versions that will be used to create client on get_array().
That can happen on developer versions of purity where api versions like 2.DEV are listed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/purefa.py


