### PR TITLE
Fix race condition with protection groups

### DIFF
--- a/changelogs/fragments/341_pg_400s.yaml
+++ b/changelogs/fragments/341_pg_400s.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_info - Fixed race condition with protection groups


### PR DESCRIPTION
##### SUMMARY
Race condition can exist where there are hundreds of protection groups and by the time we start to check some of the PGs further down the list, they could have been deleted. This will cause a crash due to "Protection group does not exist" error.

This fix checks on the error status and continues should this race condition be met.

Also apply same fix to hosts as the same race condition could happen there.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py