### PR TITLE
Add support for volume promotion and demotion

### DIFF
--- a/changelogs/fragments/342_add_vol_promotion.yaml
+++ b/changelogs/fragments/342_add_vol_promotion.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_volume - Added support for volume promotion/demotion


### PR DESCRIPTION
##### SUMMARY
Add support for individual volume promotion/demotion.
Set using new parameter `promotion_state`. Valid values are `promoted` and `demoted`.
Only works on arrays running REST 2.2 or higher.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_volume.py