### PR TITLE
Fixed parameter name in purefa_smtp

### DIFF
--- a/changelogs/fragments/344_fix_smtp.yaml
+++ b/changelogs/fragments/344_fix_smtp.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_smtp - Fix parameter name

--- a/plugins/modules/purefa_smtp.py
+++ b/plugins/modules/purefa_smtp.py
@@ -84,7 +84,7 @@ def delete_smtp(module, array):
     changed = True
     if not module.check_mode:
         try:
-            array.set_smtp(sender_domain="", username="", password="", relay_host="")
+            array.set_smtp(sender_domain="", user_name="", password="", relay_host="")
         except Exception:
             module.fail_json(msg="Delete SMTP settigs failed")
     module.exit_json(changed=changed)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixed parameter name in purefa_smtp. Replaced "username" with "user_name".

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
purefa_smtp.py
