### PR TITLE
Fix idempotency bug for volumes with QoS

### DIFF
--- a/changelogs/fragments/360_fix_volume.yaml
+++ b/changelogs/fragments/360_fix_volume.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - purefa_volume - Ensure promotion_stateus is returned correctly on creation
+  - purefa_volume - Fixed idempotency bug when creating volumes with QoS

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -747,11 +747,18 @@ def create_volume(module, array):
         if not module.check_mode:
             res = arrayv6.patch_volumes(names=[module.params["name"]], volume=volume)
             if res.status_code != 200:
+                arrayv6.patch_volumes(
+                    names=[module.params["name"]],
+                    volume=flasharray.VolumePatch(destroyed=True),
+                )
+                arrayv6.delete_volumes(names=[module.params["name"]])
                 module.fail_json(
                     msg="Failed to set Promotion State for volume {0}.".format(
                         module.params["name"]
                     )
                 )
+            else:
+                volfact["promotion_state"] = module.params["promotion_state"]
     if PRIORITY_API_VERSION in api_version and module.params["priority_operator"]:
         arrayv6 = get_array(module)
         volume = flasharray.VolumePatch(
@@ -904,6 +911,11 @@ def create_multi_volume(module, array, single=False):
                 )
                 prom_res = array.patch_volumes(names=names, volume=volume)
                 if prom_res.status_code != 200:
+                    array.patch_volumes(
+                        names=names,
+                        volume=flasharray.VolumePatch(destroyed=True),
+                    )
+                    array.delete_volumes(names=names)
                     module.warn(
                         "Failed to set promotion status on volumes. Error: {0}".format(
                             prom_res.errors[0].message
@@ -950,6 +962,13 @@ def create_multi_volume(module, array, single=False):
                     ].qos.bandwidth_limit
                 if iops_qos_size != 0:
                     volfact[vol_name]["iops_limit"] = temp[count].qos.iops_limit
+                if (
+                    VOLUME_PROMOTION_API_VERSION in api_version
+                    and module.params["promotion_state"]
+                ):
+                    volfact[vol_name]["promotion_status"] = prio_temp[
+                        count
+                    ].promotion_status
                 if (
                     PRIORITY_API_VERSION in api_version
                     and module.params["priority_operator"]
@@ -1135,7 +1154,9 @@ def update_volume(module, array):
                             )
                         )
     if module.params["bw_qos"] and QOS_API_VERSION in api_version:
-        if human_to_bytes(module.params["bw_qos"]) != vol_qos["bandwidth_limit"]:
+        if int(human_to_bytes(module.params["bw_qos"])) != int(
+            vol_qos["bandwidth_limit"]
+        ):
             if module.params["bw_qos"] == "0":
                 changed = True
                 if not module.check_mode:
@@ -1172,7 +1193,7 @@ def update_volume(module, array):
                     )
                 )
     if module.params["iops_qos"] and IOPS_API_VERSION in api_version:
-        if human_to_real(module.params["iops_qos"]) != vol_qos["iops_limit"]:
+        if int(human_to_real(module.params["iops_qos"])) != int(vol_qos["iops_limit"]):
             if module.params["iops_qos"] == "0":
                 changed = True
                 if not module.check_mode:
@@ -1224,6 +1245,7 @@ def update_volume(module, array):
                 else:
                     if not volfact:
                         volfact = array.get_volume(module.params["name"])
+                        volfact["promotion_status"] = module.params["promotion_state"]
     if PRIORITY_API_VERSION in api_version and module.params["priority_operator"]:
         arrayv6 = get_array(module)
         volv6 = list(arrayv6.get_volumes(names=[module.params["name"]]).items)[0]


### PR DESCRIPTION
##### SUMMARY
When you create a volume with QoS settings, rerunning the playbook will still flag as changed when it hasn't.

Also ensure the promotion_status is correctly returned in the volume dict.
If promotion state cannot be set correctly then don't bother creating the volume.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_volume.py