### PR TITLE
Add new NVMe service types

### DIFF
--- a/changelogs/fragments/366_add_nvme_types.yaml
+++ b/changelogs/fragments/366_add_nvme_types.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_network - Added support for NVMe-RoCE and NVMe-TCP service types
+ - purefa_vlan - Added support for NVMe-TCP service type

--- a/plugins/modules/purefa_network.py
+++ b/plugins/modules/purefa_network.py
@@ -65,7 +65,7 @@ options:
       - Note that I(system) is only valid for Cloud Block Store.
     elements: str
     type: list
-    choices: [ "replication", "management", "ds", "file", "iscsi", "scsi-fc", "nvme-fc", "system"]
+    choices: [ "replication", "management", "ds", "file", "iscsi", "scsi-fc", "nvme-fc", "nvme-tcp", "nvme-roce", "system"]
     version_added: '1.15.0'
 extends_documentation_fragment:
     - purestorage.flasharray.purestorage.fa
@@ -382,6 +382,8 @@ def main():
                     "iscsi",
                     "scsi-fc",
                     "nvme-fc",
+                    "nvme-tcp",
+                    "nvme-roce",
                     "system",
                 ],
             ),

--- a/plugins/modules/purefa_vlan.py
+++ b/plugins/modules/purefa_vlan.py
@@ -245,9 +245,9 @@ def main():
         module.fail_json(msg="Invalid subnet specified.")
     if not interface:
         module.fail_json(msg="Invalid interface specified.")
-    if ("iscsi" or "nvme-roce" or "file") not in interface["services"]:
+    if ("iscsi" or "nvme-roce" or "nvme-tcp" or "file") not in interface["services"]:
         module.fail_json(
-            msg="Invalid interface specified - must have service type of iSCSI, NVMe-RoCE or file enabled."
+            msg="Invalid interface specified - must have service type of iSCSI, NVMe-RoCE, NVMe-TCP or file enabled."
         )
     if subnet["vlan"]:
         vif_name = module.params["name"] + "." + str(subnet["vlan"])


### PR DESCRIPTION
##### SUMMARY
Add support for new `servicelist` options of `nvme-roce` and `nvme-tcp`.
Note that `nvme-tcp` requires Purity//FA 6.4.2 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_network.py
purefa_vlan.py