### PR TITLE
Missing attributes in pgsnap

### DIFF
--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -792,8 +792,11 @@ def generate_pgsnaps_dict(array):
             "suffix": snapshots[snapshot].suffix,
             "snapshot_space": snapshots[snapshot].space.snapshots,
         }
-        if pgsnaps_info[s_name]["destroyed"]:
-            pgsnaps_info[s_name]["time_remaining"] = snapshots[snapshot].time_remaining
+        try:
+            if pgsnaps_info[s_name]["destroyed"]:
+                pgsnaps_info[s_name]["time_remaining"] = snapshots[snapshot].time_remaining
+        except AttributeError:
+            pass
         try:
             pgsnaps_info[s_name]["manual_eradication"] = snapshots[
                 snapshot

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -794,7 +794,9 @@ def generate_pgsnaps_dict(array):
         }
         try:
             if pgsnaps_info[s_name]["destroyed"]:
-                pgsnaps_info[s_name]["time_remaining"] = snapshots[snapshot].time_remaining
+                pgsnaps_info[s_name]["time_remaining"] = snapshots[
+                    snapshot
+                ].time_remaining
         except AttributeError:
             pass
         try:

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -256,7 +256,7 @@ def get_pending_pgroup(module, array):
     if ":" in module.params["name"]:
         if "::" not in module.params["name"]:
             for pgrp in array.list_pgroups(pending=True, on="*"):
-                if pgrp["name"] == module.params["name"] and pgrp["time_remaining"]:
+                if pgrp["name"] == module.params["name"]:
                     pgroup = pgrp
                     break
         else:


### PR DESCRIPTION
##### SUMMARY
When the pgroup snapshot is on an offload target a destroyed pgsnap does not have a `time remaining` value. 
This patch resolves that issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py
purefa_pg.py