### PR TITLE
Ensure only local hosts are checked for VLAN

### DIFF
--- a/changelogs/fragments/374_offload_pgsnap.yaml
+++ b/changelogs/fragments/374_offload_pgsnap.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - purefa_info - Resolves issue with destroyed pgroup snapshot on an offload target not have a time remaining value
+  - purefa_pg - Resolves issue with destroyed pgroup snapshot on an offload target not have a time remaining value

--- a/changelogs/fragments/375_fix_remote_hosts.yaml
+++ b/changelogs/fragments/375_fix_remote_hosts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefa_info - Resolves issue in AC environment where REST v2 host list mismatches REST v1 due to remote hosts.

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -1450,8 +1450,9 @@ def generate_host_dict(module, array):
         arrayv6 = get_array(module)
         hosts = list(arrayv6.get_hosts().items)
         for host in range(0, len(hosts)):
-            hostname = hosts[host].name
-            host_info[hostname]["vlan"] = getattr(hosts[host], "vlan", None)
+            if hosts[host].is_local:
+                hostname = hosts[host].name
+                host_info[hostname]["vlan"] = getattr(hosts[host], "vlan", None)
     return host_info
 
 


### PR DESCRIPTION
##### SUMMARY
Fix issue in AC environment where REST v2 host list mismatches REST v1due to remote hosts. 
(Also add missing changelog fragments from 2 previous PRs)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py