### PR TITLE
Remove e2ee call for endpoints

### DIFF
--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -401,7 +401,6 @@ purefa_info:
         "volumes": {
             "@offload_boot": {
                 "bandwidth": null,
-                "host_encryption_key_status": null,
                 "hosts": [
                     [
                         "@offload",
@@ -416,7 +415,6 @@ purefa_info:
             },
             "docker-store": {
                 "bandwidth": null,
-                "host_encryption_key_status": null,
                 "hosts": [
                     [
                         "docker-host",

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -1362,7 +1362,7 @@ def generate_vol_dict(module, array):
             volume = vvols[vvol]["name"]
             volume_info[volume] = {
                 "protocol_endpoint": True,
-                "host_encryption_key_status", None,
+                "host_encryption_key_status": None,
                 "source": vvols[vvol]["source"],
                 "serial": vvols[vvol]["serial"],
                 "nvme_nguid": "eui.00"

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -1362,6 +1362,7 @@ def generate_vol_dict(module, array):
             volume = vvols[vvol]["name"]
             volume_info[volume] = {
                 "protocol_endpoint": True,
+                "host_encryption_key_status", None,
                 "source": vvols[vvol]["source"],
                 "serial": vvols[vvol]["serial"],
                 "nvme_nguid": "eui.00"
@@ -1372,15 +1373,6 @@ def generate_vol_dict(module, array):
                 "tags": [],
                 "hosts": [],
             }
-        if P53_API_VERSION in array._list_available_rest_versions():
-            pe_e2ees = array.list_volumes(
-                protocol_endpoint=True, host_encryption_key=True
-            )
-            for pe_e2ee in range(0, len(pe_e2ees)):
-                volume = pe_e2ees[pe_e2ee]["name"]
-                volume_info[volume]["host_encryption_key_status"] = pe_e2ees[pe_e2ee][
-                    "host_encryption_key_status"
-                ]
         if P53_API_VERSION in array._list_available_rest_versions():
             e2ees = array.list_volumes(host_encryption_key=True)
             for e2ee in range(0, len(e2ees)):

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -401,6 +401,7 @@ purefa_info:
         "volumes": {
             "@offload_boot": {
                 "bandwidth": null,
+                "host_encryption_key_status": null,
                 "hosts": [
                     [
                         "@offload",
@@ -415,6 +416,7 @@ purefa_info:
             },
             "docker-store": {
                 "bandwidth": null,
+                "host_encryption_key_status": null,
                 "hosts": [
                     [
                         "docker-host",


### PR DESCRIPTION
##### SUMMARY
host encryption keys and protocol endpoints are not compatible.
This has been exposed in Purity//FA 6.4.3 breaking REST 1.x calls as per #385.
Remove the offending call, but for backwards compatability retain the dict key that was created by the offending call when
it (incorrctly) returned a response.
This has no frontend visibilty so no change note required.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py