### PR TITLE
Remove Python 2.7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Pure Storage FlashArray collection consists of the latest versions of the Fl
 - Some modules require specific Purity versions
 - purestorage
 - py-pure-client
+- python >= 3.6
 - netaddr
 - requests
 - pycountry

--- a/changelogs/fragments/388_remove_27.yaml
+++ b/changelogs/fragments/388_remove_27.yaml
@@ -1,0 +1,3 @@
+release_summary: |
+   | FlashArray Collection v1.18 removes module-side support for Python 2.7.
+   | The minimum required Python version for the FlashArray Collection is Python 3.6.

--- a/plugins/modules/purefa_hg.py
+++ b/plugins/modules/purefa_hg.py
@@ -150,7 +150,7 @@ def get_hostgroup(module, array):
     hostgroup = None
 
     for host in array.list_hgroups():
-        if host["name"] == module.params["hostgroup"]:
+        if host["name"].casefold() == module.params["hostgroup"].casefold():
             hostgroup = host
             break
 

--- a/plugins/modules/purefa_hg.py
+++ b/plugins/modules/purefa_hg.py
@@ -140,7 +140,7 @@ def rename_exists(module, array):
     exists = False
     new_name = module.params["rename"]
     for hgroup in array.list_hgroups():
-        if hgroup["name"].lower() == new_name.lower():
+        if hgroup["name"].casefold() == new_name.casefold():
             exists = True
             break
     return exists
@@ -224,8 +224,8 @@ def update_hostgroup(module, array):
                     )
                 )
         if module.params["host"]:
-            cased_hosts = [host.lower() for host in module.params["host"]]
-            cased_hghosts = [host.lower() for host in hgroup["hosts"]]
+            cased_hosts = list(module.params["host"])
+            cased_hghosts = list(hgroup["hosts"])
             new_hosts = list(set(cased_hosts).difference(cased_hghosts))
             if new_hosts:
                 try:
@@ -236,8 +236,8 @@ def update_hostgroup(module, array):
                     module.fail_json(msg="Failed to add host(s) to hostgroup")
         if module.params["volume"]:
             if volumes:
-                current_vols = [vol["vol"].lower() for vol in volumes]
-                cased_vols = [vol.lower() for vol in module.params["volume"]]
+                current_vols = [vol["vol"] for vol in volumes]
+                cased_vols = list(module.params["volume"])
                 new_volumes = list(set(cased_vols).difference(set(current_vols)))
                 if len(new_volumes) == 1 and module.params["lun"]:
                     try:
@@ -296,8 +296,8 @@ def update_hostgroup(module, array):
                             )
     else:
         if module.params["host"]:
-            cased_old_hosts = [host.lower() for host in module.params["host"]]
-            cased_hosts = [host.lower() for host in hgroup["hosts"]]
+            cased_old_hosts = list(module.params["host"])
+            cased_hosts = list(hgroup["hosts"])
             old_hosts = list(set(cased_old_hosts).intersection(cased_hosts))
             if old_hosts:
                 try:
@@ -311,7 +311,7 @@ def update_hostgroup(module, array):
                         )
                     )
         if module.params["volume"]:
-            cased_old_vols = [vol.lower() for vol in module.params["volume"]]
+            cased_old_vols = list(module.params["volume"])
             old_volumes = list(
                 set(cased_old_vols).intersection(
                     set([vol["vol"].lower() for vol in volumes])

--- a/plugins/modules/purefa_host.py
+++ b/plugins/modules/purefa_host.py
@@ -692,7 +692,7 @@ def get_host(module, array):
     """Return host or None"""
     host = None
     for hst in array.list_hosts():
-        if hst["name"].lower() == module.params["name"].lower():
+        if hst["name"].casefold() == module.params["name"].casefold():
             module.params["name"] = hst["name"]
             host = hst
             break
@@ -703,7 +703,7 @@ def rename_exists(module, array):
     """Determine if rename target already exists"""
     exists = False
     for hst in array.list_hosts():
-        if hst["name"].lower() == module.params["rename"].lower():
+        if hst["name"].casefold() == module.params["rename"].casefold():
             exists = True
             break
     return exists
@@ -922,10 +922,8 @@ def main():
     )
 
     array = get_system(module)
-    module.params["name"] = module.params["name"].lower()
     pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$")
     if module.params["rename"]:
-        module.params["rename"] = module.params["rename"].lower()
         if not pattern.match(module.params["rename"]):
             module.fail_json(
                 msg="Rename value {0} does not conform to naming convention".format(

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -307,7 +307,7 @@ def get_pgroup_sched(module, array):
     pgroup = None
 
     for pgrp in array.list_pgroups(schedule=True):
-        if pgrp["name"] == module.params["name"]:
+        if pgrp["name"].casefold() == module.params["name"].casefold():
             pgroup = pgrp
             break
 

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -440,7 +440,7 @@ def rename_exists(module, array):
         if "::" in module.params["name"]:
             new_name = container + "::" + module.params["rename"]
     for pgroup in array.list_pgroups(pending=True):
-        if pgroup["name"].lower() == new_name.lower():
+        if pgroup["name"].casefold() == new_name.casefold():
             exists = True
             break
     return exists
@@ -538,8 +538,8 @@ def update_pgroup(module, array):
                         )
                     )
         else:
-            cased_vols = [vol.lower() for vol in module.params["volume"]]
-            cased_pgvols = [vol.lower() for vol in get_pgroup(module, array)["volumes"]]
+            cased_vols = list(module.params["volume"])
+            cased_pgvols = list(get_pgroup(module, array)["volumes"])
             if not all(x in cased_pgvols for x in cased_vols):
                 if not module.check_mode:
                     changed = True
@@ -573,10 +573,8 @@ def update_pgroup(module, array):
                         )
                     )
         else:
-            cased_hosts = [host.lower() for host in module.params["host"]]
-            cased_pghosts = [
-                host.lower() for host in get_pgroup(module, array)["hosts"]
-            ]
+            cased_hosts = list(module.params["host"])
+            cased_pghosts = list(get_pgroup(module, array)["hosts"])
             if not all(x in cased_pghosts for x in cased_hosts):
                 if not module.check_mode:
                     changed = True
@@ -610,10 +608,8 @@ def update_pgroup(module, array):
                         )
                     )
         else:
-            cased_hostg = [hostg.lower() for hostg in module.params["hostgroup"]]
-            cased_pghostg = [
-                hostg.lower() for hostg in get_pgroup(module, array)["hgroups"]
-            ]
+            cased_hostg = list(module.params["hostgroup"])
+            cased_pghostg = list(get_pgroup(module, array)["hgroups"])
             if not all(x in cased_pghostg for x in cased_hostg):
                 if not module.check_mode:
                     changed = True
@@ -811,7 +807,6 @@ def main():
     array = get_system(module)
     pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$")
     if module.params["rename"]:
-        module.params["rename"] = module.params["rename"].lower()
         if not pattern.match(module.params["rename"]):
             module.fail_json(
                 msg="Rename value {0} does not conform to naming convention".format(

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -256,17 +256,23 @@ def get_pending_pgroup(module, array):
     if ":" in module.params["name"]:
         if "::" not in module.params["name"]:
             for pgrp in array.list_pgroups(pending=True, on="*"):
-                if pgrp["name"] == module.params["name"]:
+                if pgrp["name"].casefold() == module.params["name"].casefold():
                     pgroup = pgrp
                     break
         else:
             for pgrp in array.list_pgroups(pending=True):
-                if pgrp["name"] == module.params["name"] and pgrp["time_remaining"]:
+                if (
+                    pgrp["name"].casefold() == module.params["name"].casefold()
+                    and pgrp["time_remaining"]
+                ):
                     pgroup = pgrp
                     break
     else:
         for pgrp in array.list_pgroups(pending=True):
-            if pgrp["name"] == module.params["name"] and pgrp["time_remaining"]:
+            if (
+                pgrp["name"].casefold() == module.params["name"].casefold()
+                and pgrp["time_remaining"]
+            ):
                 pgroup = pgrp
                 break
 
@@ -279,17 +285,17 @@ def get_pgroup(module, array):
     if ":" in module.params["name"]:
         if "::" not in module.params["name"]:
             for pgrp in array.list_pgroups(on="*"):
-                if pgrp["name"] == module.params["name"]:
+                if pgrp["name"].casefold() == module.params["name"].casefold():
                     pgroup = pgrp
                     break
         else:
             for pgrp in array.list_pgroups():
-                if pgrp["name"] == module.params["name"]:
+                if pgrp["name"].casefold() == module.params["name"].casefold():
                     pgroup = pgrp
                     break
     else:
         for pgrp in array.list_pgroups():
-            if pgrp["name"] == module.params["name"]:
+            if pgrp["name"].casefold() == module.params["name"].casefold():
                 pgroup = pgrp
                 break
 

--- a/plugins/modules/purefa_pod.py
+++ b/plugins/modules/purefa_pod.py
@@ -529,8 +529,6 @@ def main():
         argument_spec, mutually_exclusive=mutually_exclusive, supports_check_mode=True
     )
 
-    module.params["name"] = module.params["name"].lower()
-
     state = module.params["state"]
     array = get_system(module)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 purestorage
 py-pure-client
+python >= 3.6
 netaddr
 requests
 pycountry


### PR DESCRIPTION
##### SUMMARY
Remove support for Python 2.7

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_hg.py
purefa_host.py
purefa_pg.py
purefa_pod.py

##### ADDITIONAL INFORMATION
To ensure that we correctly support mixed case host objects, PGs, etc we ned to use the `casefold` function which is not supported in Python 2.7