### PR TITLE
Remove unnecessary warning and fix suffix issue

### DIFF
--- a/changelogs/fragments/393_offload_recover
+++ b/changelogs/fragments/393_offload_recover
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_snap - Fixed issue system generated suffixes not being allowed and removed unnecessary warning message

--- a/changelogs/fragments/393_offload_recover
+++ b/changelogs/fragments/393_offload_recover
@@ -1,2 +1,0 @@
-bugfixes:
- - purefa_snap - Fixed issue system generated suffixes not being allowed and removed unnecessary warning message

--- a/changelogs/fragments/393_offload_recover.yaml
+++ b/changelogs/fragments/393_offload_recover.yaml
@@ -1,2 +1,4 @@
 bugfixes:
- - purefa_snap - Fixed issue system generated suffixes not being allowed and removed unnecessary warning message
+ - purefa_snap - Fixed issue system generated suffixes not being allowed and removed unnecessary warning message.
+minor_changes:
+ - purefa_snap - New response of 'suffix' when snapshot has been created.

--- a/changelogs/fragments/393_offload_recover.yaml
+++ b/changelogs/fragments/393_offload_recover.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_snap - Fixed issue system generated suffixes not being allowed and removed unnecessary warning message

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -289,8 +289,12 @@ def create_snapshot(module, array, arrayv6):
                     module.params["name"], suffix=module.params["suffix"]
                 )
             except Exception:
-                module.fail_json(msg="Failed to create snapshot for volume {0}".format(module.params["name"]))
-    module.exit_json(changed=changed)
+                module.fail_json(
+                    msg="Failed to create snapshot for volume {0}".format(
+                        module.params["name"]
+                    )
+                )
+    module.exit_json(changed=changed, suffix=module.params["suffix"])
 
 
 def create_from_snapshot(module, array):
@@ -593,3 +597,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -531,12 +531,11 @@ def main():
 
     required_if = [("state", "copy", ["target", "suffix"])]
 
-    if not HAS_PUREERROR:
-        module.fail_json(msg="purestorage sdk is required for this module")
-
     module = AnsibleModule(
         argument_spec, required_if=required_if, supports_check_mode=True
     )
+    if not HAS_PUREERROR:
+        module.fail_json(msg="purestorage sdk is required for this module")
     pattern1 = re.compile(
         "^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$"
     )

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -488,8 +488,8 @@ def main():
     module = AnsibleModule(
         argument_spec, required_if=required_if, supports_check_mode=True
     )
-    pattern1 = (
-        re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+    pattern1 = re.compile(
+        "^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$"
     )
     pattern2 = re.compile("^([1-9])([0-9]{0,63}[0-9])?$")
 

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -488,7 +488,9 @@ def main():
     module = AnsibleModule(
         argument_spec, required_if=required_if, supports_check_mode=True
     )
-    pattern1 = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+    pattern1 = (
+        re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+    )
     pattern2 = re.compile("^([1-9])([0-9]{0,63}[0-9])?$")
 
     state = module.params["state"]

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -505,12 +505,13 @@ def main():
 
     required_if = [("state", "copy", ["target", "suffix"])]
 
-    if not HAS_PUREERROR:
-        module.fail_json(msg="purestorage sdk is required for this module")
-
     module = AnsibleModule(
         argument_spec, required_if=required_if, supports_check_mode=True
     )
+
+    if not HAS_PUREERROR:
+        module.fail_json(msg="purestorage sdk is required for this module")
+
     pattern1 = re.compile(
         "^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$"
     )

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -514,7 +514,7 @@ def main():
                     )
                 )
     if state == "rename" and module.params["target"] is not None:
-        if not pattern.match(module.params["target"]):
+        if not pattern1.match(module.params["target"]):
             module.fail_json(
                 msg="Suffix target {0} does not conform to suffix name rules".format(
                     module.params["target"]

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -266,22 +266,17 @@ def create_snapshot(module, array, arrayv6):
     """Create Snapshot"""
     changed = False
     if module.params["offload"]:
-        if module.params["suffix"]:
-            module.warn(
-                "Suffix not supported for Remote Volume Offload Snapshot. Using next incremental integer"
+        changed = True
+        if not module.check_mode:
+            res = arrayv6.post_remote_volume_snapshots(
+                source_names=[module.params["name"]], on=module.params["offload"]
             )
-            module.params["suffix"] = None
-            changed = True
-            if not module.check_mode:
-                res = arrayv6.post_remote_volume_snapshots(
-                    source_names=[module.params["name"]], on=module.params["offload"]
-                )
-                if res.status_code != 200:
-                    module.fail_json(
-                        msg="Failed to crete remote snapshot for volume {0}. Error: {1}".format(
-                            module.params["name"], res.errors[0].message
-                        )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to create remote snapshot for volume {0}. Error: {1}".format(
+                        module.params["name"], res.errors[0].message
                     )
+                )
     else:
         changed = True
         if not module.check_mode:

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -488,7 +488,8 @@ def main():
     module = AnsibleModule(
         argument_spec, required_if=required_if, supports_check_mode=True
     )
-    pattern = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+    pattern1 = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+    pattern2 = re.compile("^([1-9])([0-9]{0,63}[0-9])?$")
 
     state = module.params["state"]
     if module.params["suffix"] is None:
@@ -498,7 +499,10 @@ def main():
         module.params["suffix"] = suffix.replace(".", "")
     else:
         if not module.params["offload"]:
-            if not pattern.match(module.params["suffix"]) and state not in [
+            if not (
+                pattern1.match(module.params["suffix"])
+                or pattern2.match(module.params["suffix"])
+            ) and state not in [
                 "absent",
                 "rename",
             ]:

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -597,4 +597,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
##### SUMMARY
Remove warning about suffix for snapshot offload  (volume send)
Add second regex to allow system generated suffixes to be used for `copy`.
Add return value of `suffix` when new snapshot has been created. 
Provide error message when trying to delete a snapshot that is the baseline of a volume on another array, or is still replicating.
This occurs when you try and delete the latest snapshot from a `purevol send` invoked on another array.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_snap.py