### PR TITLE
Fix partially_connected issue

### DIFF
--- a/changelogs/fragments/397_parialconnect_bug.yaml
+++ b/changelogs/fragments/397_parialconnect_bug.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pg - Fixed issue where volumes could not be added to a PG when one of the arrays was undergoing a failover.

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -230,7 +230,7 @@ def get_targets(array):
         return None
 
     for targetcnt in range(0, len(target_details)):
-        if target_details[targetcnt]["status"] == "connected":
+        if target_details[targetcnt]["status"] in ["connected", "partially_connected"]:
             targets.append(target_details[targetcnt]["name"])
     return targets
 
@@ -242,7 +242,7 @@ def get_arrays(array):
     api_version = array._list_available_rest_versions()
     for arraycnt in range(0, len(array_details)):
         if P53_API_VERSION in api_version:
-            if array_details[arraycnt]["status"] == "connected":
+            if array_details[arraycnt]["status"] in ["connected", "partially_connected"]:
                 arrays.append(array_details[arraycnt]["array_name"])
         else:
             if array_details[arraycnt]["connected"]:

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -230,9 +230,7 @@ def get_targets(array):
         return None
 
     for targetcnt in range(0, len(target_details)):
-        if target_details[targetcnt]["status"] in [
-            "connected", "partially_connected"
-        ]:
+        if target_details[targetcnt]["status"] in ["connected", "partially_connected"]:
             targets.append(target_details[targetcnt]["name"])
     return targets
 
@@ -244,7 +242,9 @@ def get_arrays(array):
     api_version = array._list_available_rest_versions()
     for arraycnt in range(0, len(array_details)):
         if P53_API_VERSION in api_version:
-            if array_details[arraycnt]["status"] in ["connected", "partially_connected"]:
+            if array_details[arraycnt]["status"] in [
+                "connected", "partially_connected"
+            ]:
                 arrays.append(array_details[arraycnt]["array_name"])
         else:
             if array_details[arraycnt]["connected"]:

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -244,7 +244,7 @@ def get_arrays(array):
         if P53_API_VERSION in api_version:
             if array_details[arraycnt]["status"] in [
                 "connected",
-                "partially_connected"
+                "partially_connected",
             ]:
                 arrays.append(array_details[arraycnt]["array_name"])
         else:

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -230,7 +230,9 @@ def get_targets(array):
         return None
 
     for targetcnt in range(0, len(target_details)):
-        if target_details[targetcnt]["status"] in ["connected", "partially_connected"]:
+        if target_details[targetcnt]["status"] in [
+            "connected", "partially_connected"
+        ]:
             targets.append(target_details[targetcnt]["name"])
     return targets
 

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -243,7 +243,8 @@ def get_arrays(array):
     for arraycnt in range(0, len(array_details)):
         if P53_API_VERSION in api_version:
             if array_details[arraycnt]["status"] in [
-                "connected", "partially_connected"
+                "connected",
+                "partially_connected"
             ]:
                 arrays.append(array_details[arraycnt]["array_name"])
         else:


### PR DESCRIPTION
##### SUMMARY
When trying to add volumes to a PG when arrays are only partially connected, eg in a failover state, addition will fail.
This is not correct.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pg.py