### PR TITLE
Set user_mapping default

### DIFF
--- a/changelogs/fragments/411_nfs_user_mapping.yaml
+++ b/changelogs/fragments/411_nfs_user_mapping.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_policy - Set user_mapping parameter default to True

--- a/plugins/modules/purefa_policy.py
+++ b/plugins/modules/purefa_policy.py
@@ -77,6 +77,7 @@ options:
     description:
     - Defines if user mapping is enabled
     type: bool
+    default: true
     version_added: 1.14.0
   snap_at:
     description:
@@ -1540,7 +1541,7 @@ def main():
             quota_notifications=dict(
                 type="list", elements="str", choices=["user", "group"]
             ),
-            user_mapping=dict(type="bool"),
+            user_mapping=dict(type="bool", default=True),
             directory=dict(type="list", elements="str"),
         )
     )


### PR DESCRIPTION
##### SUMMARY
Set NFS policy `user_mapping` default as True.
with no default set the creation of the policy fails, but the policy is actually created and enabled.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_policy.py