### PR TITLE
Fix snapshot suffix handling

### DIFF
--- a/changelogs/fragments/412_fix_snapshot_suffix_handling.yaml
+++ b/changelogs/fragments/412_fix_snapshot_suffix_handling.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pgsnap - Update the accepted suffixes to include also numbers only. Fixed the logic to retrieve the latest completed snapshot

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -432,9 +432,13 @@ def main():
             module.params["suffix"] = suffix.replace(".", "")
         else:
             if module.params["restore"]:
-                pattern = re.compile("^[0-9]{0,63}$|^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+                pattern = re.compile(
+                    "^[0-9]{0,63}$|^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$"
+                )
             else:
-                pattern = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+                pattern = re.compile(
+                    "^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$"
+                )
             if not pattern.match(module.params["suffix"]):
                 module.fail_json(
                     msg="Suffix name {0} does not conform to suffix name rules".format(

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -285,7 +285,7 @@ def restore_pgsnapvolume(module, array):
     api_version = array._list_available_rest_versions()
     changed = True
     if module.params["suffix"] == "latest":
-        all_snaps = array.get_pgroup( module.params["name"], snap=True, transfer=True)
+        all_snaps = array.get_pgroup(module.params["name"], snap=True, transfer=True)
         all_snaps.reverse()
         for snap in all_snaps:
             if snap["completed"]:

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -285,9 +285,7 @@ def restore_pgsnapvolume(module, array):
     api_version = array._list_available_rest_versions()
     changed = True
     if module.params["suffix"] == "latest":
-        all_snaps = array.get_pgroup(
-            module.params["name"], snap=True, transfer=True
-        )
+        all_snaps = array.get_pgroup( module.params["name"], snap=True, transfer=True)
         all_snaps.reverse()
         for snap in all_snaps:
             if snap["completed"]:

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -287,9 +287,10 @@ def restore_pgsnapvolume(module, array):
     if module.params["suffix"] == "latest":
         all_snaps = array.get_pgroup(
             module.params["name"], snap=True, transfer=True
-        ).reverse()
+        )
+        all_snaps.reverse()
         for snap in all_snaps:
-            if not snap["completed"]:
+            if snap["completed"]:
                 latest_snap = snap["name"]
                 break
         try:
@@ -422,7 +423,6 @@ def main():
     module = AnsibleModule(
         argument_spec, required_if=required_if, supports_check_mode=True
     )
-    pattern = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
     state = module.params["state"]
     if state == "present":
         if module.params["suffix"] is None:
@@ -431,6 +431,10 @@ def main():
             )
             module.params["suffix"] = suffix.replace(".", "")
         else:
+            if module.params["restore"]:
+                pattern = re.compile("^[0-9]{0,63}$|^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
+            else:
+                pattern = re.compile("^(?=.*[a-zA-Z-])[a-zA-Z0-9]([a-zA-Z0-9-]{0,63}[a-zA-Z0-9])?$")
             if not pattern.match(module.params["suffix"]):
                 module.fail_json(
                     msg="Suffix name {0} does not conform to suffix name rules".format(


### PR DESCRIPTION
##### SUMMARY

Update purefa_pgsnap for better handling snapshot suffix.
Fixed the logic for retrieving the latest completed snapshots.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

purefa_pgsnap

##### ADDITIONAL INFORMATION

Unmanaged snapshots are created with a progressive numerical suffix, therefore in order to restore those it is now possible with this updare specifying a numeric value for the suffix parameter.
Furthemore the test condition in the loop that retrieves the latest completed snapshot was not working and is now fixed according to the proper logic.
