### PR TITLE
Add support for AutoDir policies

### DIFF
--- a/changelogs/fragments/415_autodir_policies.yaml
+++ b/changelogs/fragments/415_autodir_policies.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_policy - Added support for autodir policies
+ - purefa_info - Added support for autodir policies

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -129,6 +129,7 @@ VM_VERSION = "2.14"
 VLAN_VERSION = "2.17"
 NEIGHBOR_API_VERSION = "2.22"
 POD_QUOTA_VERSION = "2.23"
+AUTODIR_API_VERSION = "2.24"
 
 
 def generate_default_dict(module, array):
@@ -496,7 +497,7 @@ def generate_dir_snaps_dict(array):
     return dir_snaps_info
 
 
-def generate_policies_dict(array, quota_available, nfs_user_mapping):
+def generate_policies_dict(array, quota_available, autodir_available, nfs_user_mapping):
     policy_info = {}
     policies = list(array.get_policies().items)
     for policy in range(0, len(policies)):
@@ -576,6 +577,8 @@ def generate_policies_dict(array, quota_available, nfs_user_mapping):
                     "notifications": rules[rule].notifications,
                 }
                 policy_info[p_name]["rules"].append(quota_rules_dict)
+        if policies[policy].policy_type == "autodir" and autodir_available:
+            pass  # there are currently no rules for autodir policies
     return policy_info
 
 
@@ -2288,7 +2291,13 @@ def main():
                 quota = True
             else:
                 quota = False
-            info["policies"] = generate_policies_dict(array_v6, quota, user_map)
+            if AUTODIR_API_VERSION in api_version:
+                autodir = True
+            else:
+                autodir = False
+            info["policies"] = generate_policies_dict(
+                array_v6, quota, autodir, user_map
+            )
         if "clients" in subset or "all" in subset:
             info["clients"] = generate_clients_dict(array_v6)
         if "dir_snaps" in subset or "all" in subset:


### PR DESCRIPTION
##### SUMMARY
Add support for AutoDir policies.
Availble from REST 2.24 (Purity//FA 6.4.5)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py
purfa_policy.py