### PR TITLE
Fix bug when no suffix is provided for multiple volume creation

### DIFF
--- a/changelogs/fragments/440_null_suffix.yaml
+++ b/changelogs/fragments/440_null_suffix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_volume - Fixed bug with NULL suffix for multiple volume creation.

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -86,6 +86,7 @@ options:
       See associated descriptions
     - Only supported from Purity//FA v6.0.0 and higher
     type: str
+    default: ""
   bw_qos:
     description:
     - Bandwidth limit for volume in M or G units.
@@ -1553,7 +1554,7 @@ def main():
             count=dict(type="int"),
             start=dict(type="int", default=0),
             digits=dict(type="int", default=1),
-            suffix=dict(type="str"),
+            suffix=dict(type="str", default=""),
             priority_operator=dict(type="str", choices=["+", "-", "="]),
             priority_value=dict(type="int", choices=[-10, 0, 10]),
             size=dict(type="str"),


### PR DESCRIPTION
##### SUMMARY
Fixes issue where `suffix` is not defined when creating multiple volumes in `purefa_volume`.
Closes #439 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_volume.py