### PR TITLE
Change version checking to REST 2 methodology

### DIFF
--- a/changelogs/fragments/441_v2_version.yaml
+++ b/changelogs/fragments/441_v2_version.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - multiple - Where only REST 2.x endpoints are used, convert to REST 2.x methodology.
+ - multiple - Remove packaging pre-requisite.

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -42,5 +42,4 @@ requirements:
   - netaddr
   - requests
   - pycountry
-  - packaging
 """

--- a/plugins/modules/purefa_ad.py
+++ b/plugins/modules/purefa_ad.py
@@ -152,8 +152,10 @@ except ImportError:
     HAS_PURESTORAGE = False
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
 )
@@ -205,7 +207,7 @@ def update_account(module, array):
 def create_account(module, array, api_version):
     """Create Active Directory Account"""
     changed = True
-    if MIN_JOIN_OU_API_VERSION not in api_version:
+    if LooseVersion(MIN_JOIN_OU_API_VERSION) > LooseVersion(api_version):
         ad_config = ActiveDirectoryPost(
             computer_name=module.params["computer"],
             directory_servers=module.params["directory_servers"],
@@ -214,7 +216,7 @@ def create_account(module, array, api_version):
             user=module.params["username"],
             password=module.params["password"],
         )
-    elif MIN_TLS_API_VERSION in api_version:
+    elif LooseVersion(MIN_TLS_API_VERSION) <= LooseVersion(api_version):
         ad_config = ActiveDirectoryPost(
             computer_name=module.params["computer"],
             directory_servers=module.params["directory_servers"],
@@ -284,15 +286,14 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    array = get_array(module)
+    api_version = array.get_rest_version()
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
     state = module.params["state"]
-    array = get_array(module)
     exists = bool(
         array.get_active_directory(names=[module.params["name"]]).status_code == 200
     )
@@ -300,18 +301,22 @@ def main():
     if not module.params["computer"]:
         module.params["computer"] = module.params["name"].replace("_", "-")
     if module.params["kerberos_servers"]:
-        if SERVER_API_VERSION in api_version:
+        if LooseVersion(SERVER_API_VERSION) <= LooseVersion(api_version):
             module.params["kerberos_servers"] = module.params["kerberos_servers"][0:3]
         else:
             module.params["kerberos_servers"] = module.params["kerberos_servers"][0:1]
     if module.params["directory_servers"]:
-        if SERVER_API_VERSION in api_version:
+        if LooseVersion(SERVER_API_VERSION) <= LooseVersion(api_version):
             module.params["directory_servers"] = module.params["directory_servers"][0:3]
         else:
             module.params["directory_servers"] = module.params["directory_servers"][0:1]
     if not exists and state == "present":
         create_account(module, array, api_version)
-    elif exists and state == "present" and MIN_TLS_API_VERSION in api_version:
+    elif (
+        exists
+        and state == "present"
+        and LooseVersion(MIN_TLS_API_VERSION) <= LooseVersion(api_version)
+    ):
         update_account(module, array)
     elif exists and state == "absent":
         delete_account(module, array)

--- a/plugins/modules/purefa_admin.py
+++ b/plugins/modules/purefa_admin.py
@@ -70,9 +70,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_API_VERSION = "2.2"
@@ -95,11 +97,10 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
     if module.params["lockout"] and not 1 <= module.params["lockout"] <= 7776000:
         module.fail_json(msg="Lockout must be between 1 and 7776000 seconds")
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
     changed = False
-    if MIN_API_VERSION in api_version:
-        array = get_array(module)
+    if LooseVersion(MIN_API_VERSION) <= LooseVersion(api_version):
         current_settings = list(array.get_admins_settings().items)[0]
         if (
             module.params["sso"]

--- a/plugins/modules/purefa_apiclient.py
+++ b/plugins/modules/purefa_apiclient.py
@@ -109,9 +109,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.1"
@@ -219,15 +221,14 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
-    array = get_array(module)
     state = module.params["state"]
 
     try:

--- a/plugins/modules/purefa_certs.py
+++ b/plugins/modules/purefa_certs.py
@@ -194,9 +194,11 @@ except ImportError:
 import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.4"
@@ -502,16 +504,15 @@ def main():
         module.fail_json(msg="pycountry sdk is required for this module")
 
     email_pattern = r"^(\w|\.|\_|\-)+[@](\w|\_|\-|\.)+[.]\w{2,3}$"
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
 
-    array = get_array(module)
     if module.params["email"]:
         if not re.search(email_pattern, module.params["email"]):
             module.fail_json(

--- a/plugins/modules/purefa_default_protection.py
+++ b/plugins/modules/purefa_default_protection.py
@@ -99,11 +99,12 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
 )
-
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
+)
 
 DEFAULT_API_VERSION = "2.16"
 
@@ -282,14 +283,13 @@ def main():
         module.fail_json(
             msg="py-pure-client sdk is required to support 'count' parameter"
         )
-    arrayv5 = get_system(module)
     module.params["name"] = sorted(module.params["name"])
-    api_version = arrayv5._list_available_rest_versions()
-    if DEFAULT_API_VERSION not in api_version:
+    array = get_array(module)
+    api_version = array.get_rest_version()
+    if LooseVersion(DEFAULT_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="Default Protection is not supported. Purity//FA 6.3.4, or higher, is required."
         )
-    array = get_array(module)
     if module.params["scope"] == "pod":
         if not _get_pod(module, array):
             module.fail_json(

--- a/plugins/modules/purefa_directory.py
+++ b/plugins/modules/purefa_directory.py
@@ -90,9 +90,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.2"
@@ -190,14 +192,13 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    array = get_array(module)
+    api_version = array.get_rest_version()
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
-    array = get_array(module)
     state = module.params["state"]
 
     try:

--- a/plugins/modules/purefa_export.py
+++ b/plugins/modules/purefa_export.py
@@ -91,9 +91,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.3"
@@ -224,14 +226,13 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    array = get_array(module)
+    api_version = array.get_rest_version()
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
-    array = get_array(module)
     state = module.params["state"]
 
     exists = bool(

--- a/plugins/modules/purefa_file.py
+++ b/plugins/modules/purefa_file.py
@@ -93,16 +93,13 @@ try:
 except ImportError:
     HAS_PURESTORAGE = False
 
-HAS_PACKAGING = True
-try:
-    from packaging import version
-except ImportError:
-    HAS_PACKAGING = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.26"
@@ -146,10 +143,7 @@ def main():
     array = get_array(module)
     api_version = array.get_rest_version()
 
-    if not HAS_PACKAGING:
-        module.fail_json(msg="packaging sdk is required for this module")
-
-    if version.parse(MIN_REQUIRED_API_VERSION) > version.parse(api_version):
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)

--- a/plugins/modules/purefa_fs.py
+++ b/plugins/modules/purefa_fs.py
@@ -93,9 +93,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.2"
@@ -295,19 +297,21 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
-    if REPL_SUPPORT_API not in api_version and "::" in module.params["name"]:
+    if (
+        LooseVersion(REPL_SUPPORT_API) > LooseVersion(api_version)
+        and "::" in module.params["name"]
+    ):
         module.fail_json(
             msg="Filesystem Replication is only supported in Purity//FA 6.3.0 or higher"
         )
-    array = get_array(module)
     state = module.params["state"]
 
     try:

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -90,12 +90,10 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa impo
     get_system,
     purefa_argument_spec,
 )
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
+)
 
-HAS_PACKAGING = True
-try:
-    from packaging import version
-except ImportError:
-    HAS_PACKAGING = False
 try:
     from purestorage import purestorage
 except ImportError:
@@ -442,9 +440,7 @@ def generate_filesystems_dict(array):
                 ),
                 "exports": {},
             }
-            if version.parse(SUBS_API_VERSION) <= version.parse(
-                array.get_rest_version()
-            ):
+            if LooseVersion(SUBS_API_VERSION) <= LooseVersion(array.get_rest_version()):
                 files_info[fs_name]["directories"][d_name]["total_used"] = directories[
                     directory
                 ].space.total_used
@@ -514,7 +510,7 @@ def generate_dir_snaps_dict(array):
                 snapshots[snapshot].space, "used_provisioned", None
             ),
         }
-        if version.parse(SUBS_API_VERSION) <= version.parse(array.get_rest_version()):
+        if LooseVersion(SUBS_API_VERSION) <= LooseVersion(array.get_rest_version()):
             dir_snaps_info[s_name]["total_used"] = snapshots[snapshot].space.total_used
         try:
             dir_snaps_info[s_name]["policy"] = snapshots[snapshot].policy.name
@@ -559,13 +555,13 @@ def generate_policies_dict(array, quota_available, autodir_available, nfs_user_m
                 policy_info[p_name][
                     "user_mapping_enabled"
                 ] = nfs_policy.user_mapping_enabled
-                if version.parse(SUBS_API_VERSION) <= version.parse(
+                if LooseVersion(SUBS_API_VERSION) <= LooseVersion(
                     array.get_rest_version()
                 ):
                     policy_info[p_name]["nfs_version"] = getattr(
                         nfs_policy, "nfs_version", None
                     )
-                if version.parse(NFS_SECURITY_VERSION) <= version.parse(
+                if LooseVersion(NFS_SECURITY_VERSION) <= LooseVersion(
                     array.get_rest_version()
                 ):
                     policy_info[p_name]["security"] = getattr(
@@ -580,18 +576,16 @@ def generate_policies_dict(array, quota_available, autodir_available, nfs_user_m
                     "permission": rules[rule].permission,
                     "client": rules[rule].client,
                 }
-                if version.parse(SUBS_API_VERSION) <= version.parse(
+                if LooseVersion(SUBS_API_VERSION) <= LooseVersion(
                     array.get_rest_version()
                 ):
                     nfs_rules_dict["nfs_version"] = rules[rule].nfs_version
                 policy_info[p_name]["rules"].append(nfs_rules_dict)
         if policies[policy].policy_type == "snapshot":
-            if HAS_PACKAGING:
-                suffix_enabled = version.parse(
-                    array.get_rest_version()
-                ) >= version.parse(SHARED_CAP_API_VERSION)
-            else:
-                suffix_enabled = False
+            suffix_enabled = bool(
+                LooseVersion(array.get_rest_version())
+                >= LooseVersion(SHARED_CAP_API_VERSION)
+            )
             rules = list(array.get_policies_snapshot_rules(policy_names=[p_name]).items)
             for rule in range(0, len(rules)):
                 try:
@@ -2273,7 +2267,7 @@ def generate_google_offload_dict(array):
                 offloads[offload].space, "used_provisioned", None
             ),
         }
-        if version.parse(SUBS_API_VERSION) <= version.parse(array.get_rest_version()):
+        if LooseVersion(SUBS_API_VERSION) <= LooseVersion(array.get_rest_version()):
             offload_info[name]["total_used"] = offloads[offload].space.total_used
     return offload_info
 

--- a/plugins/modules/purefa_kmip.py
+++ b/plugins/modules/purefa_kmip.py
@@ -97,9 +97,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.2"
@@ -222,16 +224,15 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
 
-    array = get_array(module)
     state = module.params["state"]
     exists = bool(array.get_kmip(names=[module.params["name"]]).status_code == 200)
     if module.params["certificate"] and len(module.params["certificate"]) > 3000:

--- a/plugins/modules/purefa_logging.py
+++ b/plugins/modules/purefa_logging.py
@@ -66,9 +66,11 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 AUDIT_API_VERSION = "2.2"
@@ -87,13 +89,12 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
     audits = []
     changed = False
-    if AUDIT_API_VERSION in api_version:
+    if LooseVersion(AUDIT_API_VERSION) <= LooseVersion(api_version):
         changed = True
-        array = get_array(module)
         if not module.check_mode:
             if module.params["log_type"] == "audit":
                 all_audits = list(

--- a/plugins/modules/purefa_offload.py
+++ b/plugins/modules/purefa_offload.py
@@ -155,12 +155,6 @@ try:
 except ImportError:
     HAS_PURESTORAGE = False
 
-HAS_PACKAGING = True
-try:
-    from packaging import version
-except ImportError:
-    HAS_PACKAGING = False
-
 import re
 
 from ansible.module_utils.basic import AnsibleModule
@@ -168,6 +162,9 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa impo
     get_array,
     get_system,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "1.16"
@@ -442,8 +439,6 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PACKAGING:
-        module.fail_json(msg="packagingsdk is required for this module")
     if not HAS_PURESTORAGE and module.params["protocol"] == "gcp":
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
@@ -517,7 +512,7 @@ def main():
             if (
                 apps[app]["enabled"]
                 and apps[app]["status"] == "healthy"
-                and version.parse(apps[app]["version"]) >= version.parse("5.2.0")
+                and LooseVersion(apps[app]["version"]) >= LooseVersion("5.2.0")
             ):
                 all_good = True
                 app_version = apps[app]["version"]
@@ -528,7 +523,7 @@ def main():
             msg="Correct Offload app not installed or incorrectly configured"
         )
     else:
-        if version.parse(array.get()["version"]) != version.parse(app_version):
+        if LooseVersion(array.get()["version"]) != LooseVersion(app_version):
             module.fail_json(
                 msg="Offload app version must match Purity version. Please upgrade."
             )

--- a/plugins/modules/purefa_saml.py
+++ b/plugins/modules/purefa_saml.py
@@ -121,9 +121,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.11"
@@ -310,15 +312,14 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
-    array = get_array(module)
     state = module.params["state"]
 
     try:

--- a/plugins/modules/purefa_smis.py
+++ b/plugins/modules/purefa_smis.py
@@ -65,9 +65,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.2"
@@ -115,15 +117,14 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
-    array = get_array(module)
 
     update_smis(module, array)
 

--- a/plugins/modules/purefa_snmp_agent.py
+++ b/plugins/modules/purefa_snmp_agent.py
@@ -120,9 +120,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.1"
@@ -238,10 +240,10 @@ def main():
         supports_check_mode=True,
     )
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashArray REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)

--- a/plugins/modules/purefa_sso.py
+++ b/plugins/modules/purefa_sso.py
@@ -66,9 +66,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 SSO_API_VERSION = "2.2"
@@ -88,11 +90,10 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     state = module.params["state"]
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
     changed = False
-    if SSO_API_VERSION in api_version:
-        array = get_array(module)
+    if LooseVersion(SSO_API_VERSION) <= LooseVersion(api_version):
         current_sso = list(array.get_admins_settings().items)[0].single_sign_on_enabled
         if (state == "present" and not current_sso) or (
             state == "absent" and current_sso

--- a/plugins/modules/purefa_syslog_settings.py
+++ b/plugins/modules/purefa_syslog_settings.py
@@ -76,9 +76,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
-    get_system,
     get_array,
     purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
 )
 
 MIN_REQUIRED_API_VERSION = "2.9"
@@ -106,15 +108,14 @@ def main():
     if not HAS_PURESTORAGE:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
-    array = get_system(module)
-    api_version = array._list_available_rest_versions()
+    array = get_array(module)
+    api_version = array.get_rest_version()
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="Purity//FA version not supported. Minimum version required: 6.2.0"
         )
 
-    array = get_array(module)
     changed = cert_change = False
     if module.params["ca_certificate"] and len(module.params["ca_certificate"]) > 3000:
         module.fail_json(msg="Certificate exceeds 3000 characters")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ python >= 3.6
 netaddr
 requests
 pycountry
-packaging


### PR DESCRIPTION
##### SUMMARY
For modules that only use REST 2 endpoints, remove the REST 1.x API version checking and replace with REST 2 methodology.
Remove `packaging` as a pre-requisite and replace with a vendor copy of `distutils.version` to leverage `LooseVersion`(added as part of #519 )

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Multiple