### PR TITLE
PY39 issue fix for multiple DNS entries

### DIFF
--- a/changelogs/fragments/445_py39.yaml
+++ b/changelogs/fragments/445_py39.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_info - Fixed py39 specific bug with multiple DNS entries

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -283,12 +283,9 @@ def generate_config_dict(module, array):
                     "nameservers": dns_configs[config].nameservers,
                     "domain": dns_configs[config].domain,
                 }
-                try:
-                    config_info["dns"][dns_configs[config].services[0]][
-                        "source"
-                    ] = dns_configs[config].source["name"]
-                except Exception:
-                    pass
+                config_info["dns"][dns_configs[config].services[0]]["source"] = getattr(
+                    dns_configs[config].source, "name", None
+                )
         if SAML2_VERSION in api_version:
             config_info["saml2sso"] = {}
             saml2 = list(arrayv6.get_sso_saml2_idps().items)


### PR DESCRIPTION
##### SUMMARY
Python 3.9 produces a strange error message when multiple DNS entries are used in a FA.
This is not seen in any other Python version.
This fix mitigates for PY39

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py