### PR TITLE
Add NFS v4 support

### DIFF
--- a/changelogs/fragments/463_nfs_version.yaml
+++ b/changelogs/fragments/463_nfs_version.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_policy - Added support for multiple NFS versions from Purity//FA 6.4.10


### PR DESCRIPTION
##### SUMMARY
Add `nfs_version` option to support NFSv4 and/or NFSv3. If not specified defaults to NFSv3.
Requires Purity//FA 6.4.10 or higher

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_policy.py