### PR TITLE
Fixes error using force_bind_password

### DIFF
--- a/changelogs/fragments/464_fix_ds_add.yaml
+++ b/changelogs/fragments/464_fix_ds_add.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_ds - Fixes issue with creating a new ds configuration while setting force_bind_password as "false".

--- a/plugins/modules/purefa_ds.py
+++ b/plugins/modules/purefa_ds.py
@@ -434,8 +434,8 @@ def update_ds_v6(module, array):
         base_dn = module.params["base_dn"]
         ds_change = True
     if module.params["bind_user"] != "":
-        bind_user = module.params["bind_user"]
-        if module.params["bind_user"] != current_ds.bind_user:
+        if module.params["bind_user"] != bind_user:
+            bind_user = module.params["bind_user"]
             password_required = True
             ds_change = True
         elif module.params["force_bind_password"]:

--- a/plugins/modules/purefa_ds.py
+++ b/plugins/modules/purefa_ds.py
@@ -435,7 +435,7 @@ def update_ds_v6(module, array):
         ds_change = True
     if module.params["bind_user"] != "":
         bind_user = module.params["bind_user"]
-        if module.params["bind_user"] != bind_user:
+        if module.params["bind_user"] != current_ds.bind_user:
             password_required = True
             ds_change = True
         elif module.params["force_bind_password"]:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes a logic error. The line before the if statement, the variables `bind_user` is being set to `module.params["bind_user"]` and then the if statement is checking is `bind_user` is equal to `module.params["bind_user"]`. This is causing the following code in the if statement to never run. Due to this, if you use the parameter `force_bind_password: false` when calling `purefa_ds` and there is no existing directories services configuration you receive an error.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #464 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
purefa_ds

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- All new PRs must include a changelog fragment
- Details of naming convention and format can be found [here](https://docs.ansible.com/ansible/latest/community/development_process.html#creating-a-changelog-fragment)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
