### PR TITLE
Add missing subset name

### DIFF
--- a/changelogs/fragments/468_missing_subset.yaml
+++ b/changelogs/fragments/468_missing_subset.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_info - Added missing alerts subset name

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -2376,6 +2376,7 @@ def main():
         "policies",
         "dir_snaps",
         "filesystems",
+        "alerts",
         "virtual_machines",
         "hosts_balance",
         "subscriptions",


### PR DESCRIPTION
##### SUMMARY
Add missing `alert` subset

Closes #447

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py