### PR TITLE
Enabled to eradicate destroyed pgsnap

### DIFF
--- a/changelogs/fragments/488_fix_pgsnap_eradication.yaml
+++ b/changelogs/fragments/488_fix_pgsnap_eradication.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pgsnap - Enabled to eradicate destroyed snapshots.

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -601,7 +601,7 @@ def main():
         delete_offload_snapshot(module, array)
     elif state == "rename" and pgsnap:
         update_pgsnapshot(module)
-    elif state == "absent" and pgsnap:
+    elif state == "absent" and pgsnap and not pgsnap_deleted:
         delete_pgsnapshot(module, array)
     elif state == "absent" and pgsnap and pgsnap_deleted and module.params["eradicate"]:
         eradicate_pgsnapshot(module, array)


### PR DESCRIPTION
##### SUMMARY
Enabled to eradicate destroyed protection group snapshots.
Added "not pgsnap_deleted" to the conditional expression so that "eradicate_pgsnapshot" would be executed for already-deleted snapshots. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py