### PR TITLE
Update create_pgsnapshot in purefa_pgsnap.py renaming throttle parame…

### DIFF
--- a/changelogs/fragments/516_fix_throttle.yaml
+++ b/changelogs/fragments/516_fix_throttle.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pgsnap - Fixed incorrect parameter name

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -321,14 +321,14 @@ def create_pgsnapshot(module, array):
                         source_names=[module.params["name"]],
                         apply_retention=module.params["apply_retention"],
                         replicate_now=True,
-                        throttle=module.params["throttle"],
+                        allow_throttle=module.params["throttle"],
                         protection_group_snapshot=suffix,
                     )
                 else:
                     res = arrayv6.post_protection_group_snapshots(
                         source_names=[module.params["name"]],
                         apply_retention=module.params["apply_retention"],
-                        throttle=module.params["throttle"],
+                        allow_throttle=module.params["throttle"],
                         protection_group_snapshot=suffix,
                         replicate=module.params["remote"],
                     )
@@ -336,7 +336,7 @@ def create_pgsnapshot(module, array):
                 res = arrayv6.post_protection_group_snapshots(
                     source_names=[module.params["name"]],
                     apply_retention=module.params["apply_retention"],
-                    throttle=module.params["throttle"],
+                    allow_throttle=module.params["throttle"],
                     protection_group_snapshot=suffix,
                 )
 


### PR DESCRIPTION
…ter of protection_group_snapshots_post to allow_throttle

"create_pgsnapshot" in plugins/modules/purefa_pgsnap.py calls "protection_group_snapshots_api.py" from the py-pure-client with the wrongly named parameter "throttle" instead of "allow_throttle" to fail if array health is not optimal.

This causes the error:
Traceback (most recent call last):
  File "[...]/AnsiballZ_purefa_pgsnap.py", line 107, in <module>
    _ansiballz_main()
  File "[...]/AnsiballZ_purefa_pgsnap.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "[...]/AnsiballZ_purefa_pgsnap.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.purestorage.flasharray.plugins.modules.purefa_pgsnap', init_globals=dict(_module_fqn='ansible_collections.purestorage.flasharray.plugins.modules.purefa_pgsnap', _modlib_path=modlib_path),
  File "/usr/lib64/python3.9/runpy.py",line 225, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.9/runpy.py", line 97, in _run_module_code
_run_code(code, mod_globals, init_globals,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "[...]/purefa_pgsnap.py", line 615, in <module>
  File "[...]/purefa_pgsnap.py", line 593, in main
  File "[...]/purefa_pgsnap.py", line 336, in create_pgsnapshot
TypeError: post_protection_group_snapshots() got an unexpected keyword argument 'throttle'

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py