### PR TITLE
Add support for NFS policy security flavors

### DIFF
--- a/changelogs/fragments/518_nfs_security.yaml
+++ b/changelogs/fragments/518_nfs_security.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_policy - Added NFS security flavors for accessing files in the mount point.
+ - purefa_info - Expose NFS security flavor for policies

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -132,6 +132,7 @@ POD_QUOTA_VERSION = "2.23"
 AUTODIR_API_VERSION = "2.24"
 SUBS_API_VERSION = "2.26"
 NSID_API_VERSION = "2.27"
+NFS_SECURITY_VERSION = "2.29"
 
 
 def generate_default_dict(module, array):
@@ -556,6 +557,12 @@ def generate_policies_dict(array, quota_available, autodir_available, nfs_user_m
                 ):
                     policy_info[p_name]["nfs_version"] = getattr(
                         nfs_policy, "nfs_version", None
+                    )
+                if version.parse(NFS_SECURITY_VERSION) <= version.parse(
+                    array.get_rest_version()
+                ):
+                    policy_info[p_name]["security"] = getattr(
+                        nfs_policy, "security", None
                     )
             rules = list(
                 array.get_policies_nfs_client_rules(policy_names=[p_name]).items


### PR DESCRIPTION
##### SUMMARY
Add new parameter `security` to apply security flavors to NFS policies.
Requires Purity//FA 6.6.2 minimum (REST 2.29)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_policy.py
purefa_info.py