### PR TITLE
Fix issue with empty DS dict

### DIFF
--- a/changelogs/fragments/524_empty_ds.yaml
+++ b/changelogs/fragments/524_empty_ds.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_ds - Fix issue with SDK returning empty data for data directory services even when it does exist


### PR DESCRIPTION
##### SUMMARY
In recent SDK version `get_directory_services()` used with `filter="name=..."` returns an empty dict if the service is `data`.
This leads to a crash in the module.
This patch fixes the issue by removing the `filter` call and interates through all services until the correct one is found.

Also remove unnecessary parameters when updating a data directory service.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_ds.py