### PR TITLE
Convert syslog to REST 2

### DIFF
--- a/changelogs/fragments/536_syslog_rest.yaml
+++ b/changelogs/fragments/536_syslog_rest.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_syslog - ``name`` becomes a required parameter as module converts to full REST 2 support


### PR DESCRIPTION
##### SUMMARY
Convert syslog module to REST 2.
This requires the `name` parameter to become required and also allows a better functionality for updating an existing syslog server.
Closes #532 

##### ISSUE TYPE
- REST 2 Pull Request

##### COMPONENT NAME
purefa_syslog.py