### PR TITLE
Fix for netaddr==1.0.0

### DIFF
--- a/plugins/modules/purefa_network.py
+++ b/plugins/modules/purefa_network.py
@@ -338,9 +338,12 @@ def update_interface(module, array, interface):
     else:
         enabled = current_state["enabled"]
     if not current_state["gateway"]:
-        if valid_ipv4(interface["address"]):
-            current_state["gateway"] = None
-        elif valid_ipv6(interface["address"]):
+        try:
+            if valid_ipv4(interface["address"]):
+                current_state["gateway"] = None
+            elif valid_ipv6(interface["address"]):
+                current_state["gateway"] = None
+        except AttributeError:
             current_state["gateway"] = None
     if not module.params["servicelist"]:
         services = sorted(interface["services"])


### PR DESCRIPTION
##### SUMMARY
Change in `netaddr` from v1.0.0 causes error when passing `None` to `valid_ipv4`
This fix caters for this new error whilst retaining functionality for older `netaddr` versions.
Closes #543 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_network.py