### PR TITLE
Allow 4K certificates

### DIFF
--- a/changelogs/fragments/545_4kcert.yaml
+++ b/changelogs/fragments/545_4kcert.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_certs - Allow certificates of over 3000 characters to be imported.

--- a/plugins/modules/purefa_certs.py
+++ b/plugins/modules/purefa_certs.py
@@ -333,12 +333,11 @@ def delete_cert(module, array):
 def import_cert(module, array, reimport=False):
     """Import a CA provided SSL certificate"""
     changed = True
-    if len(module.params["certificate"]) > 3000:
-        module.fail_json(msg="Imported Certificate exceeds 3000 characters")
     certificate = flasharray.CertificatePost(
         certificate=module.params["certificate"],
         intermediate_certificate=module.params["intermeadiate_cert"],
         key=module.params["key"],
+        key_size=module.params["key_size"],
         passphrase=module.params["passphrase"],
         status="imported",
     )


### PR DESCRIPTION
##### SUMMARY
Allow certificates larger than 3000 characters to be imported to  aFlashArray.
`key_size` must be provided if the certificate is not 2K, therefore for a 4K certificate you must provide `key_size: 4096`
Closes #545 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_certs.py