### PR TITLE
Fix subinterface neighbor issue

### DIFF
--- a/changelogs/fragments/547_lacp_neighbor_info.yaml
+++ b/changelogs/fragments/547_lacp_neighbor_info.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefa_info - Resolved issue with KeyError when LACP bonds are in use

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -700,8 +700,144 @@ def generate_network_dict(module, array):
         for neighbor in range(0, len(neighbors)):
             neighbor_info = neighbors[neighbor]
             int_name = neighbor_info.local_port.name
-            net_info[int_name].update(
-                {
+            try:
+                net_info[int_name].update(
+                    {
+                        "neighbor": {
+                            "initial_ttl_in_sec": neighbor_info.initial_ttl_in_sec,
+                            "neighbor_port": {
+                                "description": getattr(
+                                    neighbor_info.neighbor_port, "description", None
+                                ),
+                                "name": getattr(
+                                    neighbor_info.neighbor_chassis, "name", None
+                                ),
+                                "id": getattr(
+                                    neighbor_info.neighbor_port.id, "value", None
+                                ),
+                            },
+                            "neighbor_chassis": {
+                                "addresses": getattr(
+                                    neighbor_info.neighbor_chassis, "addresses", None
+                                ),
+                                "description": getattr(
+                                    neighbor_info.neighbor_chassis, "description", None
+                                ),
+                                "name": getattr(
+                                    neighbor_info.neighbor_chassis, "name", None
+                                ),
+                                "bridge": {
+                                    "enabled": getattr(
+                                        neighbor_info.neighbor_chassis.bridge,
+                                        "enabled",
+                                        False,
+                                    ),
+                                    "supported": getattr(
+                                        neighbor_info.neighbor_chassis.bridge,
+                                        "supported",
+                                        False,
+                                    ),
+                                },
+                                "repeater": {
+                                    "enabled": getattr(
+                                        neighbor_info.neighbor_chassis.repeater,
+                                        "enabled",
+                                        False,
+                                    ),
+                                    "supported": getattr(
+                                        neighbor_info.neighbor_chassis.repeater,
+                                        "supported",
+                                        False,
+                                    ),
+                                },
+                                "router": {
+                                    "enabled": getattr(
+                                        neighbor_info.neighbor_chassis.router,
+                                        "enabled",
+                                        False,
+                                    ),
+                                    "supported": getattr(
+                                        neighbor_info.neighbor_chassis.router,
+                                        "supported",
+                                        False,
+                                    ),
+                                },
+                                "station_only": {
+                                    "enabled": getattr(
+                                        neighbor_info.neighbor_chassis.station_only,
+                                        "enabled",
+                                        False,
+                                    ),
+                                    "supported": getattr(
+                                        neighbor_info.neighbor_chassis.station_only,
+                                        "supported",
+                                        False,
+                                    ),
+                                },
+                                "telephone": {
+                                    "enabled": getattr(
+                                        neighbor_info.neighbor_chassis.telephone,
+                                        "enabled",
+                                        False,
+                                    ),
+                                    "supported": getattr(
+                                        neighbor_info.neighbor_chassis.telephone,
+                                        "supported",
+                                        False,
+                                    ),
+                                },
+                                "wlan_access_point": {
+                                    "enabled": getattr(
+                                        neighbor_info.neighbor_chassis.wlan_access_point,
+                                        "enabled",
+                                        False,
+                                    ),
+                                    "supported": getattr(
+                                        neighbor_info.neighbor_chassis.wlan_access_point,
+                                        "supported",
+                                        False,
+                                    ),
+                                },
+                                "docsis_cable_device": {
+                                    "enabled": getattr(
+                                        neighbor_info.neighbor_chassis.docsis_cable_device,
+                                        "enabled",
+                                        False,
+                                    ),
+                                    "supported": getattr(
+                                        neighbor_info.neighbor_chassis.docsis_cable_device,
+                                        "supported",
+                                        False,
+                                    ),
+                                },
+                                "id": {
+                                    "type": getattr(
+                                        neighbor_info.neighbor_chassis.id,
+                                        "type",
+                                        None,
+                                    ),
+                                    "value": getattr(
+                                        neighbor_info.neighbor_chassis.id,
+                                        "value",
+                                        None,
+                                    ),
+                                },
+                            },
+                        }
+                    }
+                )
+            except KeyError:
+                net_info[int_name] = {
+                    "hwaddr": None,
+                    "mtu": None,
+                    "enabled": None,
+                    "speed": None,
+                    "address": None,
+                    "slaves": None,
+                    "services": None,
+                    "gateway": None,
+                    "netmask": None,
+                    "subnet": None,
                     "neighbor": {
                         "initial_ttl_in_sec": neighbor_info.initial_ttl_in_sec,
                         "neighbor_port": {
@@ -822,9 +958,9 @@ def generate_network_dict(module, array):
                                 ),
                             },
                         },
-                    }
+                    },
                 }
-            )
+
     return net_info
 
 


### PR DESCRIPTION
##### SUMMARY
When subinterfaces are used the physical ports are not identified as network interfaces, but still appear in the network interface neighbors response.
This fix adds the unknown interface with just the neighbor response and all other fields for an interface as empty.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py