### PR TITLE
Enhance PG group updating capabilities

### DIFF
--- a/changelogs/fragments/555_update_pg.yaml
+++ b/changelogs/fragments/555_update_pg.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_pg - Enhance ``state absent`` to work on volumes, hosts and hostgroups


### PR DESCRIPTION
##### SUMMARY
Update PG module to specify the deletion of specific items from a protection group.

Previously `state: absent` only worked on the whole protection group.
Now if you specify `volume`, `host`, or `hostgroup` with `state: absent` only those specified items will be removed from the protection group.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_pg.py