### PR TITLE
Add created_epoch to snapshots response

### DIFF
--- a/changelogs/fragments/600_snapshot_epoch.yaml
+++ b/changelogs/fragments/600_snapshot_epoch.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_snap - Add ``created_epoch`` parameter in response

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -1082,6 +1082,9 @@ def generate_snap_dict(module, array):
             "size": snaps[snap]["size"],
             "source": snaps[snap]["source"],
             "created": snaps[snap]["created"],
+            "created_epoch": int(
+                time.mktime(time.strptime(snaps[snap]["created"], "%Y-%m-%dT%H:%M:%SZ"))
+            ),
             "tags": [],
             "remote": [],
         }


### PR DESCRIPTION
##### SUMMARY
To enable playbooks to determine age of snapshots added the `created_epoch`value for each snapshot dict.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py