### PR TITLE
Add purefa_sessions module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The Pure Storage FlashArray collection consists of the latest versions of the Fl
 - requests
 - pycountry
 - packaging
+- pyz
 
 ## Installation
 
@@ -138,7 +139,8 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefa_policy - manage FlashArray NFS, SMB and snapshot policies
 - purefa_proxy - manage the phonehome HTTPS proxy setting for the FlashArray
 - purefa_ra - manage the Remote Assist setting for the FlashArray
-- purefa_saml - Manage FlashArray SAML2 service and identity providers
+- purefa_saml - manage FlashArray SAML2 service and identity providers
+- purefa_sessions - get FlashArray sessions log
 - purefa_smis - manage SMI-S settings on the FlashArray
 - purefa_smtp - manage SMTP settings on the FlashArray
 - purefa_snap - manage local snapshots on the FlashArray

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -11,6 +11,20 @@ __metaclass__ = type
 This module adds shared functions for the FlashArray modules
 """
 
+import platform
+import os
+import re
+
+from ansible.module_utils.common.process import get_bin_path
+from ansible.module_utils.facts.utils import get_file_content
+
+
+def _findstr(text, match):
+    for line in text.splitlines():
+        if match in line:
+            found = line
+    return found
+
 
 def human_to_bytes(size):
     """Given a human-readable byte string (e.g. 2G, 30M),
@@ -87,3 +101,75 @@ def convert_time_to_millisecs(time):
             return int(time[:-1]) * 60000
     except Exception:
         return 0
+
+
+def get_local_tz(module, timezone="UTC"):
+    """
+    We will attempt to get the local timezone of the server running the module and use that.
+    If we can't get the timezone then we will set the default to be UTC
+
+    Linnux has been tested and other opersting systems should be OK.
+    Failures cause assumption of UTC
+
+    Windows is not supported and will assume UTC
+    """
+    if platform.system() == "Linux":
+        timedatectl = get_bin_path("timedatectl")
+        if timedatectl is not None:
+            rcode, stdout, stderr = module.run_command(timedatectl)
+            if rcode == 0 and stdout:
+                line = _findstr(stdout, "Time zone")
+                full_tz = line.split(":", 1)[1].rstrip()
+                timezone = full_tz.split()[0]
+                return timezone
+            else:
+                module.warn("Incorrect timedatectl output. Timezone will be set to UTC")
+        else:
+            if os.path.exists("/etc/timezone"):
+                timezone = get_file_content("/etc/timezone")
+            else:
+                module.warn("Could not find /etc/timezone. Assuming UTC")
+
+    elif platform.system() == "SunOS":
+        if os.path.exists("/etc/default/init"):
+            for line in get_file_content("/etc/default/init", "").splitlines():
+                if line.startswith("TZ="):
+                    timezone = line.split("=", 1)[1]
+                    return timezone
+        else:
+            module.warn("Could not find /etc/default/init. Assuming UTC")
+
+    elif re.match("^Darwin", platform.platform()):
+        systemsetup = get_bin_path("systemsetup")
+        if systemsetup is not None:
+            rcode, stdout, stderr = module.execute(systemsetup, "-gettimezone")
+            if rcode == 0 and stdout:
+                timezone = stdout.split(":", 1)[1].lstrip()
+            else:
+                module.warn("Could not run systemsetup. Assuming UTC")
+        else:
+            module.warn("Could not find systemsetup. Assuming UTC")
+
+    elif re.match("^(Free|Net|Open)BSD", platform.platform()):
+        if os.path.exists("/etc/timezone"):
+            timezone = get_file_content("/etc/timezone")
+        else:
+            module.warn("Could not find /etc/timezone. Assuming UTC")
+
+    elif platform.system() == "AIX":
+        aix_oslevel = int(platform.version() + platform.release())
+        if aix_oslevel >= 61:
+            if os.path.exists("/etc/environment"):
+                for line in get_file_content("/etc/environment", "").splitlines():
+                    if line.startswith("TZ="):
+                        timezone = line.split("=", 1)[1]
+                        return timezone
+            else:
+                module.warn("Could not find /etc/environment. Assuming UTC")
+        else:
+            module.warn(
+                "Cannot determine timezone when AIX os level < 61. Assuming UTC"
+            )
+    else:
+        module.warn("Could not find /etc/timezone. Assuming UTC")
+    return timezone

--- a/plugins/modules/purefa_sessions.py
+++ b/plugins/modules/purefa_sessions.py
@@ -1,0 +1,209 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2024, Simon Dodsley (simon@purestorage.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefa_sessions
+version_added: '1.29.0'
+short_description: List FlashArray Sessions
+description:
+- List sessions based on filters provided
+author:
+- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+options:
+  start:
+    description:
+    - Start date and time (based on array local time)
+    - If not provided epoch is assumed
+    - Expected format "YYYY-MM-DD hh:mm:ss"
+    type: str
+  end:
+    description:
+    - End date and time (based on array local time)
+    - If not provided epoch is assumed
+    - Expected format "YYYY-MM-DD hh:mm:ss"
+    type: str
+  timezone:
+    description:
+    - The timezone of the FlashArray
+    - If not provided, the module will attempt to get the current local timezone
+      from the server however from Purity//FA 6.5.3 this value will calculated
+      automatically from the FlashArray
+    type: str
+extends_documentation_fragment:
+- purestorage.flasharray.purestorage.fa
+"""
+
+EXAMPLES = r"""
+- name: Show all sessions that started after the specified date/time
+  purefa_sessions:
+    start: "2024-06-29 12:31:34"
+    fa_url: 10.10.10.2
+    api_token: 89a9356f-c203-d263-8a89-c229486a13ba
+
+- name: Show all sessions that started and ended between specified dates/times
+  purefa_sessions:
+    start: "2024-06-29 12:31:34"
+    end: "2024-06-30 04:23:34"
+    fa_url: 10.10.10.2
+    api_token: 89a9356f-c203-d263-8a89-c229486a13ba
+
+- name: Show all sessions that ended after the specified date/time
+  purefa_sessions:
+    end: "2024-06-30 04:23:34"
+    fa_url: 10.10.10.2
+    api_token: 89a9356f-c203-d263-8a89-c229486a13ba
+
+- name: Show all sessions that have been logged by the array (to the internal limit of the array)
+  purefa_sessions:
+    fa_url: 10.10.10.2
+    api_token: 89a9356f-c203-d263-8a89-c229486a13ba
+"""
+
+RETURN = r"""
+"""
+
+HAS_PYTZ = True
+try:
+    import pytz
+except ImportError:
+    HAS_PYTX = False
+
+import datetime
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
+    get_array,
+    purefa_argument_spec,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
+)
+from ansible_collections.purestorage.flasharray.plugins.module_utils.common import (
+    get_local_tz,
+)
+
+TZ_VERSION = "2.26"
+
+
+def _get_filter_string(module, timezone):
+    filter_string = ""
+    if module.params["end"]:
+        if module.params["end"] != "0":
+            end = module.params["end"] + " " + timezone
+            end_timestamp = int(
+                1000
+                * datetime.datetime.timestamp(
+                    datetime.datetime.strptime(end, "%Y-%m-%d %H:%M:%S %z")
+                )
+            )
+        else:
+            end_timestamp = 0
+    if module.params["start"]:
+        if module.params["start"] != "0":
+            start = module.params["start"] + " " + timezone
+            start_timestamp = int(
+                1000
+                * datetime.datetime.timestamp(
+                    datetime.datetime.strptime(start, "%Y-%m-%d %H:%M:%S %z")
+                )
+            )
+        else:
+            start_timestamp = 0
+    if module.params["end"] and module.params["start"]:
+        filter_string = (
+            "start_time>="
+            + str(start_timestamp)
+            + " and end_time<="
+            + str(end_timestamp)
+        )
+    elif module.params["end"] and not module.params["start"]:
+        filter_string = "end_time<=" + str(end_timestamp)
+    elif module.params["start"] and not module.params["end"]:
+        filter_string = "start_time>=" + str(start_timestamp)
+    return filter_string
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            start=dict(type="str"),
+            end=dict(type="str"),
+            timezone=dict(type="str"),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PYTZ:
+        module.fail_json(msg="pytz is required for this module")
+
+    array = get_array(module)
+    api_version = array.get_rest_version()
+    if not module.params["timezone"] and LooseVersion(TZ_VERSION) <= LooseVersion(
+        api_version
+    ):
+        timezone = list(array.get_arrays().items)[0].time_zone
+    elif not module.params["timezone"]:
+        timezone = get_local_tz(module)
+    elif module.params["timezone"] not in pytz.all_timezones_set:
+        module.fail_json(
+            msg="Timezone {0} is not valid".format(module.params["timezone"])
+        )
+    else:
+        timezone = module.params["timezone"]
+    tzoffset = datetime.datetime.now(pytz.timezone(timezone)).strftime("%z")
+    filter_string = _get_filter_string(module, tzoffset)
+    session_log = {}
+    if filter_string:
+        res = array.get_sessions(filter=filter_string)
+    else:
+        res = array.get_sessions()
+    if res.status_code == 200:
+        sessions = list(res.items)
+    else:
+        module.fail_json(
+            msg="Failed to get sessions. Error: {0}".format(res.errors[0].message)
+        )
+    for session in range(0, len(sessions)):
+        name = sessions[session].name
+        if sessions[session].start_time:
+            start_time = datetime.datetime.fromtimestamp(
+                sessions[session].start_time / 1000, tz=pytz.timezone(timezone)
+            ).strftime("%Y-%m-%d %H:%M:%S %Z")
+        else:
+            start_time = "-"
+        if sessions[session].end_time:
+            end_time = datetime.datetime.fromtimestamp(
+                sessions[session].end_time / 1000, tz=pytz.timezone(timezone)
+            ).strftime("%Y-%m-%d %H:%M:%S %Z")
+        else:
+            end_time = "-"
+        session_log[name] = {
+            "start_time": start_time,
+            "end_time": end_time,
+            "interface": sessions[session].user_interface,
+            "user": getattr(sessions[session], "user", ""),
+            "location": sessions[session].location,
+            "repeat": getattr(sessions[session], "event_count", ""),
+            "event": sessions[session].event,
+            "method": getattr(sessions[session], "method", ""),
+        }
+    module.exit_json(changed=False, purefa_sessions=session_log)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+distro
 purestorage
 py-pure-client
 python >= 3.6
 netaddr
 requests
 pycountry
+pytz


### PR DESCRIPTION
##### SUMMARY
Add module `purefa_sessions` to get data from the FlashArray sessions log.
Parameters are:
`start` - Human readable time in format %Y-%m-%d %H:%M:%S. If not provided will default to Null.
`end` - Human readable time in format %Y-%m-%d %H:%M:%S. If not provided will default to Null.
`timezone` - Official `pytz` timezone name, eg America/Los_Angeles, for the human readable timestamps. If not provided and the FlashArray is running an appropriate version of Purity//FA this will be obtained from the FlashArray, otherwise the timezone of the system running the Ansible playbook will be used.
Add new function to `common` module

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
purefa_sessions
module_utils/common.py