### PR TITLE
Add disable_warnings parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The Pure Storage FlashArray collection consists of the latest versions of the Fl
 - pycountry
 - packaging
 - pyz
+- urllib3
 
 ## Installation
 

--- a/changelogs/fragments/588_disable_warnings.yaml
+++ b/changelogs/fragments/588_disable_warnings.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - all - add ``disable_warnings`` parameters

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -30,6 +30,12 @@ options:
     description:
       - FlashArray API token for admin privileged user.
     type: str
+  disable_warnings:
+    description:
+     - Disable insecure certificate warnings in debug logs
+    type: bool
+    default: false
+    version_added: '1.29.0'
 notes:
   - This module requires the C(purestorage) and C(py-pure-client) Python libraries
   - Additional Python librarues may be required for specific modules.
@@ -42,4 +48,5 @@ requirements:
   - netaddr
   - requests
   - pycountry
+  - urllib3
 """

--- a/plugins/module_utils/purefa.py
+++ b/plugins/module_utils/purefa.py
@@ -32,6 +32,12 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+HAS_URLLIB3 = True
+try:
+    import urllib3
+except ImportError:
+    HAS_URLLIB3 = False
+
 HAS_DISTRO = True
 try:
     import distro
@@ -59,6 +65,8 @@ USER_AGENT_BASE = "Ansible"
 
 def get_system(module):
     """Return System Object or Fail"""
+    if HAS_URLLIB3 and module.params["disable_warnings"]:
+        urllib3.disable_warnings()
     if HAS_DISTRO:
         user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
             "base": USER_AGENT_BASE,
@@ -105,6 +113,8 @@ def get_system(module):
 
 def get_array(module):
     """Return System Object or Fail"""
+    if HAS_URLLIB3 and module.params["disable_warnings"]:
+        urllib3.disable_warnings()
     if HAS_DISTRO:
         user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
             "base": USER_AGENT_BASE,
@@ -156,4 +166,5 @@ def purefa_argument_spec():
     return dict(
         fa_url=dict(),
         api_token=dict(no_log=True),
+        disable_warnings=dict(type="bool", default=False),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ netaddr
 requests
 pycountry
 pytz
+urllib3


### PR DESCRIPTION
##### SUMMARY
Add parameter `disable_warnings` (default is False) to apply to all modules.
If enabled, this will disable all insecure certificate warnings in debug messages.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa.py