### PR TITLE
HSBC hostgroup delete edge case

### DIFF
--- a/changelogs/fragments/593_hsbc_hg.yaml
+++ b/changelogs/fragments/593_hsbc_hg.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_hg - Fix edge case with incorrectly deleted hostgroup when empty array sent for volumes or hosts

--- a/plugins/modules/purefa_hg.py
+++ b/plugins/modules/purefa_hg.py
@@ -415,9 +415,9 @@ def main():
 
     if hostgroup and state == "present":
         update_hostgroup(module, array)
-    elif hostgroup and module.params["volume"] and state == "absent":
+    elif hostgroup and module.params["volume"] is not None and state == "absent":
         update_hostgroup(module, array)
-    elif hostgroup and module.params["host"] and state == "absent":
+    elif hostgroup and module.params["host"] is not None and state == "absent":
         update_hostgroup(module, array)
     elif hostgroup and state == "absent":
         delete_hostgroup(module, array)


### PR DESCRIPTION
##### SUMMARY
Fix HSBC edge case where `volume: []`  and `state: absent` deletes the whole hostgroup.
`[]` was parsed due to an error from a previous task and deleting the hostgroup was not the expected result.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_hg.py