### PR TITLE
Fix function name typo - dsrole

### DIFF
--- a/plugins/modules/purefa_dsrole.py
+++ b/plugins/modules/purefa_dsrole.py
@@ -104,7 +104,7 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa impo
 def update_role(module, array):
     """Update Directory Service Role"""
     changed = False
-    role = list(array.get_directory_service_roles(names=[module.params["role"]]).items)[
+    role = list(array.get_directory_services_roles(names=[module.params["role"]]).items)[
         0
     ]
     if (
@@ -192,7 +192,7 @@ def main():
     array = get_array(module)
     role_configured = False
     role = list(
-        array.get_directory_service_roles(
+        array.get_directory_services_roles(
             roles=[FixedReference(name=module.params["role"])]
         ).items
     )[0]


### PR DESCRIPTION
##### SUMMARY
Fix typo in function name call.
Closes #598 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_dsrole.py