### PR TITLE
Fix param name typo - purefa_pg

### DIFF
--- a/changelogs/fragments/600_pg_param_typo.yaml
+++ b/changelogs/fragments/600_pg_param_typo.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pg - Fix parameter name typo

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -946,8 +946,8 @@ def main():
         and state == "absent"
         and (
             module.params["volume"]
-            or module.params["hosts"]
-            or module.params["hostgroups"]
+            or module.params["host"]
+            or module.params["hostgroup"]
         )
     ):
         update_pgroup(module, array)


### PR DESCRIPTION
##### SUMMARY
Fix typo in parameter name
Closes #597 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pg.py