### PR TITLE
Fix netaddr compatability issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Pure Storage FlashArray collection consists of the latest versions of the Fl
 - purestorage
 - py-pure-client
 - python >= 3.9
-- netaddr
+- netaddr >= 1.2.0
 - requests
 - pycountry
 - packaging

--- a/changelogs/fragments/633_netaddr_fix.yaml
+++ b/changelogs/fragments/633_netaddr_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_network - Fix compatability issue with ``netaddr>=1.2.0``

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ distro
 purestorage
 py-pure-client
 python >= 3.6
-netaddr
+netaddr >= 1.2.0
 requests
 pycountry
 pytz


### PR DESCRIPTION
##### SUMMARY
Fix compatibility issue with `netaddr>=1.2.0`
Update requirements for `netaddr`
Remove `mtu` default setting. Let the FA tell you what the current/default setting should be.
Closes #629 

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
purefa_network.py
README.md
requirements.txt