### PR TITLE
Fixed issue of unable to move volume from pod to vgroup

### DIFF
--- a/changelogs/fragments/636_volume_fix.yaml
+++ b/changelogs/fragments/636_volume_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_volume - Fixed issue of unable to move volume from pod to vgroup

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -1352,7 +1352,7 @@ def move_volume(module, array):
             module.fail_json(
                 msg="Move location {0} does not exist.".format(module.params["move"])
             )
-        if "::" in module.params["name"]:
+        if "::" in module.params["name"] and not vgroup_exists:
             pod = array.get_pod(module.params["move"])
             if len(pod["arrays"]) > 1:
                 module.fail_json(msg="Volume cannot be moved out of a stretched pod")


### PR DESCRIPTION
##### SUMMARY

Unable to move volume from pod to vgroup.
Fixed by adding required condition to avoid checking vgroup as pod.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

purefa_volume.py