### PR TITLE
Added error message to warn about moving protected volume

### DIFF
--- a/changelogs/fragments/637_volume_add_err_msg.yaml
+++ b/changelogs/fragments/637_volume_add_err_msg.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_volume - Added error message to warn about moving protected volume

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -1286,6 +1286,10 @@ def move_volume(module, array):
     pod_name = ""
     vgroup_name = ""
     volume_name = module.params["name"]
+    pg_info = array.get_volume(volume_name, pending=True, protect=True)
+    pgs = [item['protection_group'] for item in pg_info if 'protection_group' in item ]
+    if pgs:
+        module.fail_json(msg="Cannot move volume in protection groups {0}, disassociate to proceed".format(pgs))
     if "::" in module.params["name"]:
         volume_name = module.params["name"].split("::")[1]
         pod_name = module.params["name"].split("::")[0]


### PR DESCRIPTION
##### SUMMARY

Added error message to warn about moving protected volume.
Volume should be de-attached from protection group before moving.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

purefa_volume.py