### PR TITLE
Fix keep_for parameter

### DIFF
--- a/changelogs/fragments/641_dirsnap_keep_for.yaml
+++ b/changelogs/fragments/641_dirsnap_keep_for.yaml
@@ -1,2 +1,4 @@
 bugfixes:
  - purefa_dirsnap - Fixed issues with ``keep_for`` setting and issues related to recovery of deleted snapshots
+minor_changes:
+ - purefa_info - Add ``time_remaining`` field for non-deleted directory snapshots

--- a/changelogs/fragments/641_dirsnap_keep_for.yaml
+++ b/changelogs/fragments/641_dirsnap_keep_for.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_dirsnap - Fixed issues with ``keep_for`` setting and issues related to recovery of deleted snapshots

--- a/plugins/modules/purefa_dirsnap.py
+++ b/plugins/modules/purefa_dirsnap.py
@@ -237,7 +237,7 @@ def delete_snap(module, array):
 
 def update_snap(module, array, snap_detail):
     """Update a filesystem snapshot retention time"""
-    changed = True
+    changed = False
     snapname = (
         module.params["filesystem"]
         + ":"
@@ -268,6 +268,7 @@ def update_snap(module, array, snap_detail):
         directory_snapshot = DirectorySnapshotPatch(
             client_name=new_client, suffix=new_suffix
         )
+        changed = True
         if not module.check_mode:
             res = array.patch_directory_snapshots(
                 names=[snapname], directory_snapshot=directory_snapshot
@@ -281,13 +282,14 @@ def update_snap(module, array, snap_detail):
             else:
                 snapname = new_snapname
     if not module.params["keep_for"] or module.params["keep_for"] == 0:
-        keep_for = 0
+        keep_for = None
     elif 300 <= module.params["keep_for"] <= 31536000:
         keep_for = module.params["keep_for"] * 1000
     else:
         module.fail_json(msg="keep_for not in range of 300 - 31536000")
-    if not module.check_mode:
-        if snap_detail.destroyed:
+    if snap_detail.destroyed:
+        changed = True
+        if not module.check_mode:
             directory_snapshot = DirectorySnapshotPatch(destroyed=False)
             res = array.patch_directory_snapshots(
                 names=[snapname], directory_snapshot=directory_snapshot
@@ -298,8 +300,21 @@ def update_snap(module, array, snap_detail):
                         snapname, res.errors[0].message
                     )
                 )
+            if keep_for != 0: # Set a new keep-for after recovery if requested
+                directory_snapshot = DirectorySnapshotPatch(keep_for=keep_for)
+                res = array.patch_directory_snapshots(
+                    names=[snapname], directory_snapshot=directory_snapshot
+                )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to retention time for snapshot {0}. Error: {1}".format(
+                            snapname, res.errors[0].message
+                        )
+                    )
+    if keep_for:
         directory_snapshot = DirectorySnapshotPatch(keep_for=keep_for)
-        if snap_detail.time_remaining == 0 and keep_for != 0:
+        changed = True
+        if not module.check_mode:
             res = array.patch_directory_snapshots(
                 names=[snapname], directory_snapshot=directory_snapshot
             )
@@ -309,18 +324,19 @@ def update_snap(module, array, snap_detail):
                         snapname, res.errors[0].message
                     )
                 )
-        elif snap_detail.time_remaining > 0:
-            if module.params["rename"] and module.params["keep_for"]:
-                res = array.patch_directory_snapshots(
-                    names=[snapname], directory_snapshot=directory_snapshot
-                )
-                if res.status_code != 200:
-                    module.fail_json(
-                        msg="Failed to retention time for renamed snapshot {0}. Error: {1}".format(
-                            snapname, res.errors[0].message
-                        )
+    if module.params["rename"] and keep_for:
+        directory_snapshot = DirectorySnapshotPatch(keep_for=keep_for)
+        changed = True
+        if not module.check_mode:
+            res = array.patch_directory_snapshots(
+                names=[new_snapname], directory_snapshot=directory_snapshot
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to retention time for renamed snapshot {0}. Error: {1}".format(
+                        snapname, res.errors[0].message
                     )
-
+                )
     module.exit_json(changed=changed)
 
 
@@ -329,7 +345,7 @@ def create_snap(module, array):
     changed = True
     if not module.check_mode:
         if not module.params["keep_for"] or module.params["keep_for"] == 0:
-            keep_for = None
+            keep_for = 0
         elif 300 <= module.params["keep_for"] <= 31536000:
             keep_for = module.params["keep_for"] * 1000
         else:
@@ -454,7 +470,7 @@ def main():
             snap_exists = bool(snap_detail.total_item_count != 0)
     if snap_exists:
         snap_facts = list(snap_detail.items)[0]
-    if state == "present" and not snap_exists:
+    if state == "present" and not snap_exists and not module.params['rename']:
         create_snap(module, array)
     elif state == "present" and snap_exists and module.params["suffix"]:
         update_snap(module, array, snap_facts)

--- a/plugins/modules/purefa_dirsnap.py
+++ b/plugins/modules/purefa_dirsnap.py
@@ -345,7 +345,7 @@ def create_snap(module, array):
     changed = True
     if not module.check_mode:
         if not module.params["keep_for"] or module.params["keep_for"] == 0:
-            keep_for = 0
+            keep_for = None
         elif 300 <= module.params["keep_for"] <= 31536000:
             keep_for = module.params["keep_for"] * 1000
         else:

--- a/plugins/modules/purefa_dirsnap.py
+++ b/plugins/modules/purefa_dirsnap.py
@@ -300,7 +300,7 @@ def update_snap(module, array, snap_detail):
                         snapname, res.errors[0].message
                     )
                 )
-            if keep_for != 0: # Set a new keep-for after recovery if requested
+            if keep_for != 0:  # Set a new keep-for after recovery if requested
                 directory_snapshot = DirectorySnapshotPatch(keep_for=keep_for)
                 res = array.patch_directory_snapshots(
                     names=[snapname], directory_snapshot=directory_snapshot

--- a/plugins/modules/purefa_dirsnap.py
+++ b/plugins/modules/purefa_dirsnap.py
@@ -470,7 +470,7 @@ def main():
             snap_exists = bool(snap_detail.total_item_count != 0)
     if snap_exists:
         snap_facts = list(snap_detail.items)[0]
-    if state == "present" and not snap_exists and not module.params['rename']:
+    if state == "present" and not snap_exists and not module.params["rename"]:
         create_snap(module, array)
     elif state == "present" and snap_exists and module.params["suffix"]:
         update_snap(module, array, snap_facts)

--- a/plugins/modules/purefa_dirsnap.py
+++ b/plugins/modules/purefa_dirsnap.py
@@ -329,7 +329,7 @@ def create_snap(module, array):
     changed = True
     if not module.check_mode:
         if not module.params["keep_for"] or module.params["keep_for"] == 0:
-            keep_for = 0
+            keep_for = None
         elif 300 <= module.params["keep_for"] <= 31536000:
             keep_for = module.params["keep_for"] * 1000
         else:

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -605,8 +605,8 @@ def generate_dir_snaps_dict(array):
         except Exception:
             dir_snaps_info[s_name]["policy"] = ""
         if (dir_snaps_info[s_name]["destroyed"] or
-                hasattr(snapshots[snapshot], 'time_remaining'
-            ):
+                hasattr(snapshots[snapshot], 'time_remaining')
+           ):
             dir_snaps_info[s_name]["time_remaining"] = snapshots[
                 snapshot
             ].time_remaining

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -605,7 +605,7 @@ def generate_dir_snaps_dict(array):
         except Exception:
             dir_snaps_info[s_name]["policy"] = ""
         if dir_snaps_info[s_name]["destroyed"] or hasattr(
-            snapshots[snapshot], 'time_remaining'
+            snapshots[snapshot], "time_remaining"
         ):
             dir_snaps_info[s_name]["time_remaining"] = snapshots[
                 snapshot

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -582,10 +582,14 @@ def generate_dir_snaps_dict(array):
     snapshots = list(array.get_directory_snapshots().items)
     for snapshot in range(0, len(snapshots)):
         s_name = snapshots[snapshot].name
+        if hasattr(snapshots[snapshot], 'suffix'):
+            suffix = snapshots[snapshot].suffix
+        else:
+            suffix = snapshots[snapshot].name.split('.')[-1]
         dir_snaps_info[s_name] = {
             "destroyed": snapshots[snapshot].destroyed,
             "source": snapshots[snapshot].source.name,
-            "suffix": snapshots[snapshot].suffix,
+            "suffix": suffix,
             "client_name": snapshots[snapshot].client_name,
             "snapshot_space": snapshots[snapshot].space.snapshots,
             "total_physical_space": snapshots[snapshot].space.total_physical,
@@ -600,7 +604,9 @@ def generate_dir_snaps_dict(array):
             dir_snaps_info[s_name]["policy"] = snapshots[snapshot].policy.name
         except Exception:
             dir_snaps_info[s_name]["policy"] = ""
-        if dir_snaps_info[s_name]["destroyed"]:
+        if (dir_snaps_info[s_name]["destroyed"] or
+                hasattr(snapshots[snapshot], 'time_remaining'
+            ):
             dir_snaps_info[s_name]["time_remaining"] = snapshots[
                 snapshot
             ].time_remaining

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -582,10 +582,10 @@ def generate_dir_snaps_dict(array):
     snapshots = list(array.get_directory_snapshots().items)
     for snapshot in range(0, len(snapshots)):
         s_name = snapshots[snapshot].name
-        if hasattr(snapshots[snapshot], 'suffix'):
+        if hasattr(snapshots[snapshot], "suffix"):
             suffix = snapshots[snapshot].suffix
         else:
-            suffix = snapshots[snapshot].name.split('.')[-1]
+            suffix = snapshots[snapshot].name.split(".")[-1]
         dir_snaps_info[s_name] = {
             "destroyed": snapshots[snapshot].destroyed,
             "source": snapshots[snapshot].source.name,
@@ -604,9 +604,9 @@ def generate_dir_snaps_dict(array):
             dir_snaps_info[s_name]["policy"] = snapshots[snapshot].policy.name
         except Exception:
             dir_snaps_info[s_name]["policy"] = ""
-        if (dir_snaps_info[s_name]["destroyed"] or
-                hasattr(snapshots[snapshot], 'time_remaining')
-           ):
+        if dir_snaps_info[s_name]["destroyed"] or hasattr(
+            snapshots[snapshot], 'time_remaining'
+        ):
             dir_snaps_info[s_name]["time_remaining"] = snapshots[
                 snapshot
             ].time_remaining


### PR DESCRIPTION
##### SUMMARY
When no `keep_for` is specified, the value defaulted to 0, however this should have been `None`.
Also fix issues with recovery of snapshots and correct application of `keep_for`
Add `time_remaining` for non-deleted directory snapshots in info module.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_dirsnap.py
purefa_info.py