### PR TITLE
Errors out when pgroup and add_to_pgs used incorrectly

### DIFF
--- a/changelogs/fragments/642_volume_pg_fix.yaml
+++ b/changelogs/fragments/642_volume_pg_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_volume - Errors out when pgroup and add_to_pgs used incorrectly

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -319,6 +319,12 @@ try:
 except ImportError:
     HAS_PURESTORAGE = False
 
+HAS_PACKAGING = True
+try:
+    from packaging import version
+except ImportError:
+    HAS_PACKAGING = False
+
 import re
 import time
 from ansible.module_utils.basic import AnsibleModule
@@ -334,7 +340,6 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.common impo
 from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
     LooseVersion,
 )
-from packaging import version
 
 QOS_API_VERSION = "1.14"
 VGROUPS_API_VERSION = "1.13"

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -334,6 +334,7 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.common impo
 from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
     LooseVersion,
 )
+from packaging import version
 
 QOS_API_VERSION = "1.14"
 VGROUPS_API_VERSION = "1.13"

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -550,7 +550,7 @@ def create_volume(module, array):
     """Create Volume"""
     changed = False
     api_version = array._list_available_rest_versions()
-    pg_check(module, array)
+    pg_check(module)
     if "/" in module.params["name"] and not check_vgroup(module, array):
         module.fail_json(
             msg="Failed to create volume {0}. Volume Group does not exist.".format(
@@ -762,7 +762,7 @@ def create_multi_volume(module, array, single=False):
     volfact = {}
     changed = True
     api_version = array._list_available_rest_versions()
-    pg_check(module, array)
+    pg_check(module)
     bw_qos_size = iops_qos_size = 0
     names = []
     if "/" in module.params["name"] and not check_vgroup(module, array):
@@ -1050,7 +1050,8 @@ def copy_from_volume(module, array):
     )
 
 
-def pg_check(module, array):
+def pg_check(module):
+    array = get_array(module)
     rest_version = array.get_rest_version()
     if (
         LooseVersion(rest_version) >= LooseVersion(DEFAULT_API_VERSION)
@@ -1069,7 +1070,7 @@ def update_volume(module, array):
     changed = False
     arrayv6 = None
     api_version = array._list_available_rest_versions()
-    pg_check(module, array)
+    pg_check(module)
     if MULTI_VOLUME_VERSION in api_version:
         arrayv6 = get_array(module)
     vol = array.get_volume(module.params["name"])

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -1052,10 +1052,13 @@ def copy_from_volume(module, array):
 
 def pg_check(module, array):
     rest_version = array.get_rest_version()
-    if LooseVersion(rest_version) >= LooseVersion("2.16") and module.params["pgroup"]:
+    if (
+        LooseVersion(rest_version) >= LooseVersion(DEFAULT_API_VERSION)
+        and module.params["pgroup"]
+    ):
         module.fail_json(msg="For Purity//FA 6.3.4 or higher, use add_to_pgs parameter")
     elif (
-        LooseVersion(rest_version) <= LooseVersion("2.16")
+        LooseVersion(rest_version) <= LooseVersion(DEFAULT_API_VERSION)
         and module.params["add_to_pgs"]
     ):
         module.fail_json(msg="For Purity//FA 6.3.4 or lower, use pgroup parameter")

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -1051,14 +1051,11 @@ def copy_from_volume(module, array):
 
 
 def pg_check(module, array):
-    purity_version = array.get()["version"]
-    if (
-        LooseVersion(purity_version) >= LooseVersion("6.3.4")
-        and module.params["pgroup"]
-    ):
+    rest_version = array.get_rest_version()
+    if LooseVersion(rest_version) >= LooseVersion("2.16") and module.params["pgroup"]:
         module.fail_json(msg="For Purity//FA 6.3.4 or higher, use add_to_pgs parameter")
     elif (
-        LooseVersion(purity_version) <= LooseVersion("6.3.4")
+        LooseVersion(rest_version) <= LooseVersion("2.16")
         and module.params["add_to_pgs"]
     ):
         module.fail_json(msg="For Purity//FA 6.3.4 or lower, use pgroup parameter")

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -319,12 +319,6 @@ try:
 except ImportError:
     HAS_PURESTORAGE = False
 
-HAS_PACKAGING = True
-try:
-    from packaging import version
-except ImportError:
-    HAS_PACKAGING = False
-
 import re
 import time
 from ansible.module_utils.basic import AnsibleModule
@@ -768,6 +762,7 @@ def create_multi_volume(module, array, single=False):
     volfact = {}
     changed = True
     api_version = array._list_available_rest_versions()
+    pg_check(module, array)
     bw_qos_size = iops_qos_size = 0
     names = []
     if "/" in module.params["name"] and not check_vgroup(module, array):
@@ -1058,15 +1053,15 @@ def copy_from_volume(module, array):
 def pg_check(module, array):
     purity_version = array.get()["version"]
     if (
-        version.parse(purity_version) >= version.parse("6.3.4")
+        LooseVersion(purity_version) >= LooseVersion("6.3.4")
         and module.params["pgroup"]
     ):
-        module.fail_json(msg="For purity version above 6.3.4, use add_to_pgs parameter")
+        module.fail_json(msg="For Purity//FA 6.3.4 or higher, use add_to_pgs parameter")
     elif (
-        version.parse(purity_version) <= version.parse("6.3.4")
+        LooseVersion(purity_version) <= LooseVersion("6.3.4")
         and module.params["add_to_pgs"]
     ):
-        module.fail_json(msg="For purity version below 6.3.4, use pgroup parameter")
+        module.fail_json(msg="For Purity//FA 6.3.4 or lower, use pgroup parameter")
 
 
 def update_volume(module, array):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 distro
-packaging
 purestorage
 py-pure-client
 python >= 3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 distro
+packaging
 purestorage
 py-pure-client
 python >= 3.6


### PR DESCRIPTION
##### SUMMARY
Errors out when pgroup and add_to_pgs used incorrectly
Below purity version 6.3.4 should use pgroup and above 6.3.4 should use add_to_pgs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_volume.py