### PR TITLE
Ensure response with bad power supply

### DIFF
--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -123,9 +123,9 @@ def generate_new_hardware_dict(array):
         if components[component].type == "power_supply":
             hw_info["power"][component_name] = {
                 "status": components[component].status,
-                "voltage": components[component].voltage,
-                "serial": components[component].serial,
-                "model": components[component].model,
+                "voltage": getattr(components[component], "voltage", None),
+                "serial": getattr(components[component], "serial", None),
+                "model": getattr(components[component], "model", None),
             }
     drives = list(array.get_drives().items)
     for drive in range(0, len(drives)):


### PR DESCRIPTION
##### SUMMARY
Ensure get all fields even with a bad power supply, or ones that don't provide details.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_inventory.py