### PR TITLE
Fix AttributeError when no start or end time in session record

### DIFF
--- a/changelogs/fragments/645_session_attr.yaml
+++ b/changelogs/fragments/645_session_attr.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_sessions - Correctly report sessions with no start or end time

--- a/plugins/modules/purefa_sessions.py
+++ b/plugins/modules/purefa_sessions.py
@@ -180,13 +180,13 @@ def main():
         )
     for session in range(0, len(sessions)):
         name = sessions[session].name
-        if sessions[session].start_time:
+        if hasattr(sessions[session], "start_time"):
             start_time = datetime.datetime.fromtimestamp(
                 sessions[session].start_time / 1000, tz=pytz.timezone(timezone)
             ).strftime("%Y-%m-%d %H:%M:%S %Z")
         else:
             start_time = "-"
-        if sessions[session].end_time:
+        if hasattr(sessions[session], "end_time"):
             end_time = datetime.datetime.fromtimestamp(
                 sessions[session].end_time / 1000, tz=pytz.timezone(timezone)
             ).strftime("%Y-%m-%d %H:%M:%S %Z")


### PR DESCRIPTION
##### SUMMARY
Allow session to be correctly reported even with no start or end time.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_sessions.py