### PR TITLE
Allow lacp bonds to be VIF children

### DIFF
--- a/changelogs/fragments/647_lacp_vif.yaml
+++ b/changelogs/fragments/647_lacp_vif.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_network - Allow LACP bonds to be children of a VIF


### PR DESCRIPTION
##### SUMMARY
Ensure LACP bonds are correctly allowed as children of a VIF
Closes #646 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_network.py