### PR TITLE
Fix audits issue with no start time

### DIFF
--- a/changelogs/fragments/649_audits.yaml
+++ b/changelogs/fragments/649_audits.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_audits - Fix issue when ``start`` parameter not supplied

--- a/plugins/modules/purefa_audits.py
+++ b/plugins/modules/purefa_audits.py
@@ -82,7 +82,7 @@ TZ_VERSION = "2.26"
 
 def _get_filter_string(module, timezone):
     filter_string = ""
-    if module.params["start"] != "0":
+    if module.params["start"] and module.params["start"] != "0":
         start = module.params["start"] + " " + timezone
         start_timestamp = int(
             1000


### PR DESCRIPTION
##### SUMMARY
Resolve crash when no `start` parameter is supplied

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_audits.py