### PR TITLE
Remove default MTU value

### DIFF
--- a/changelogs/fragments/653_remove_default_mtu.yaml
+++ b/changelogs/fragments/653_remove_default_mtu.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_subnet - Remove default value for MTU t ostop restting to default on enable/disable of subnet. Creation will still default to 1500 if not provided.

--- a/plugins/modules/purefa_subnet.py
+++ b/plugins/modules/purefa_subnet.py
@@ -56,7 +56,6 @@ options:
     description:
       - MTU size of the subnet. Range is 568 to 9000.
     required: false
-    default: 1500
     type: int
   vlan:
     description:
@@ -319,7 +318,7 @@ def main():
             state=dict(type="str", default="present", choices=["present", "absent"]),
             gateway=dict(type="str"),
             enabled=dict(type="bool", default=True),
-            mtu=dict(type="int", default=1500),
+            mtu=dict(type="int"),
             vlan=dict(type="int"),
         )
     )


### PR DESCRIPTION
##### SUMMARY
No need to default value for MTU. This is forcing a reset of the MTU when enabling or disabling a subnet.
If not provided when creating a new subnet it will still default to 1500 though.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_subnet.py