### PR TITLE
Move KMIP to REST v2

### DIFF
--- a/changelogs/fragments/655_kmip_v2.yaml
+++ b/changelogs/fragments/655_kmip_v2.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_info - Update KMIP information collection to use REST v2, exposing full certifcate content

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -2573,14 +2573,14 @@ def generate_certs_dict(array):
 def generate_kmip_dict(array):
     kmip_info = {}
     kmips = list(array.get_kmip().items)
-        for kmip in range(0, len(kmips)):
-            key = kmips[kmip].name
-            kmip_info[key] = {
-                "certificate": kmips[kmip].certificate.name,
-                "ca_certificate": kmips[kmip].ca_certificate,
-                "ca_cert_configured": True,
-                "uri": kmips[kmip].uris,
-            }
+    for kmip in range(0, len(kmips)):
+        key = kmips[kmip].name
+        kmip_info[key] = {
+            "certificate": kmips[kmip].certificate.name,
+            "ca_certificate": kmips[kmip].ca_certificate,
+            "ca_cert_configured": True,
+            "uri": kmips[kmip].uris,
+        }
     return kmip_info
 
 

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -2576,7 +2576,8 @@ def generate_kmip_dict(array):
         for kmip in range(0, len(kmips)):
             key = kmips[kmip].name
             kmip_info[key] = {
-                "certificate": kmips[kmip].certificate,
+                "certificate": kmips[kmip].certificate.name,
+                "ca_certificate": kmips[kmip].ca_certificate,
                 "ca_cert_configured": True,
                 "uri": kmips[kmip].uris,
             }

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -2572,15 +2572,13 @@ def generate_certs_dict(array):
 
 def generate_kmip_dict(array):
     kmip_info = {}
-    api_version = array._list_available_rest_versions()
-    if P53_API_VERSION in api_version:
-        kmips = array.list_kmip()
+    kmips = list(array.get_kmip().items)
         for kmip in range(0, len(kmips)):
-            key = kmips[kmip]["name"]
+            key = kmips[kmip].name
             kmip_info[key] = {
-                "certificate": kmips[kmip]["certificate"],
-                "ca_cert_configured": kmips[kmip]["ca_certificate_configured"],
-                "uri": kmips[kmip]["uri"],
+                "certificate": kmips[kmip].certificate,
+                "ca_cert_configured": True,
+                "uri": kmips[kmip].uris,
             }
     return kmip_info
 
@@ -3147,10 +3145,10 @@ def main():
         info["arrays"] = generate_conn_array_dict(module, array)
     if "certs" in subset or "all" in subset:
         info["certs"] = generate_certs_dict(array)
-    if "kmip" in subset or "all" in subset:
-        info["kmip"] = generate_kmip_dict(array)
     if FILES_API_VERSION in api_version:
         array_v6 = get_array(module)
+        if "kmip" in subset or "all" in subset:
+            info["kmip"] = generate_kmip_dict(array_v6)
         if "offload" in subset or "all" in subset:
             info["google_offload"] = generate_google_offload_dict(array_v6)
         if "filesystems" in subset or "all" in subset:


### PR DESCRIPTION
##### SUMMARY
To ensure multiple URIs are listed per KMIP, move KMIP info generation to use REST v2.
This requires a deprecated parameter to be forced to be `True` to ensure backwards compatibility with the old REST v1 response.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py