### PR TITLE
Update DS roles to support management access policies

### DIFF
--- a/changelogs/fragments/666_dsrole_update.yaml
+++ b/changelogs/fragments/666_dsrole_update.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_info - Expose directory service role management access policies if they exist
+ - purefa_dsrole - Add support for non-system-defined directory service roles with new parameter `name`

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -368,7 +368,7 @@ def generate_config_dict(module, array):
         config_info["directory_service_roles"] = {}
         roles = list(arrayv6.get_directory_services_roles().items)
         for role in range(0, len(roles)):
-            role_name = roles[role].name
+            role_name = roles[role].role.name
             config_info["directory_service_roles"][role_name] = {
                 "group": getattr(roles[role], "group", None),
                 "group_base": getattr(roles[role], "group_base", None),

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -135,6 +135,7 @@ NFS_SECURITY_VERSION = "2.29"
 UPTIME_API_VERSION = "2.30"
 TLS_CONNECTION_API_VERSION = "2.33"
 RA_API_VERSION = "2.35"
+DSROLE_POLICY_API_VERSION = "2.36"
 
 
 def _is_cbs(array):
@@ -367,14 +368,16 @@ def generate_config_dict(module, array):
         config_info["directory_service_roles"] = {}
         roles = list(arrayv6.get_directory_services_roles().items)
         for role in range(0, len(roles)):
-            role_name = roles[role].role.name
-            try:
-                config_info["directory_service_roles"][role_name] = {
-                    "group": roles[role].group,
-                    "group_base": roles[role].group_base,
-                }
-            except Exception:
-                pass
+            role_name = roles[role].name
+            config_info["directory_service_roles"][role_name] = {
+                "group": getattr(roles[role], "group", None),
+                "group_base": getattr(roles[role], "group_base", None),
+                "management_access_policies": None,
+            }
+            if DSROLE_POLICY_API_VERSION in api_version:
+                config_info["directory_service_roles"][role_name][
+                    "management_access_policies"
+                ] = getattr(roles[role].management_access_policies[0], "name", None)
         smi_s = list(arrayv6.get_smi_s().items)[0]
         config_info["smi-s"] = {
             "slp_enabled": smi_s.slp_enabled,


### PR DESCRIPTION
##### SUMMARY
From Purity//FA 6.6.11 additional directory service roles can be created beyond the system-defined ones.
Update dsrole module to support use of `name` parameter to create new policies. 
Update info module to show management-access-policies for DS roles.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py
purefa_dsrole.py