### PR TITLE
Update Default system-defined DS Roles

### DIFF
--- a/changelogs/fragments/673_system_dsrole.yaml
+++ b/changelogs/fragments/673_system_dsrole.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_ds - Fixed issue with trying to create a pre-existing system-defined role

--- a/plugins/modules/purefa_dsrole.py
+++ b/plugins/modules/purefa_dsrole.py
@@ -151,13 +151,12 @@ def update_role(module, array):
     role = list(
         array.get_directory_services_roles(names=[module.params["name"]]).items
     )[0]
-    #Change how you handle system-defined roles
     if module.params["name"] not in [
-            "array_admin",
-            "storage_admin",
-            "ops_admin",
-            "readonly",
-        ]:
+        "array_admin",
+        "storage_admin",
+        "ops_admin",
+        "readonly",
+    ]:
         if (
             role.group_base != module.params["group_base"]
             or role.group != module.params["group"]
@@ -179,23 +178,25 @@ def update_role(module, array):
                             module.params["name"], res.errors[0].message
                         )
                     )
-    #system-defined roles logic, missing idempotency checks
     else:
-        changed = True
-        if not module.check_mode:
-            res = array.patch_directory_services_roles(
-                names=[module.params["name"]],
-                directory_service_roles=DirectoryServiceRole(
-                    group_base=module.params["group_base"],
-                    group=module.params["group"]
-                ), #role is removed as you can't edit a system-defined role
-            )
-            if res.status_code != 200:
-                module.fail_json(
-                    msg="Update Directory Service Role {0} failed.Error: {1}".format(
-                        module.params["name"], res.errors[0].message
-                    )
+        if (
+            role.group_base != module.params["group_base"]
+            or role.group != module.params["group"]
+        ):
+            changed = True
+            if not module.check_mode:
+                res = array.patch_directory_services_roles(
+                    names=[module.params["name"]],
+                    directory_service_roles=DirectoryServiceRole(
+                        group_base=module.params["group_base"], group=module.params["group"]
+                    ),
                 )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Update Directory Service Role {0} failed.Error: {1}".format(
+                            module.params["name"], res.errors[0].message
+                        )
+                    )
     module.exit_json(changed=changed)
 
 

--- a/plugins/modules/purefa_dsrole.py
+++ b/plugins/modules/purefa_dsrole.py
@@ -188,7 +188,8 @@ def update_role(module, array):
                 res = array.patch_directory_services_roles(
                     names=[module.params["name"]],
                     directory_service_roles=DirectoryServiceRole(
-                        group_base=module.params["group_base"], group=module.params["group"]
+                        group_base=module.params["group_base"],
+                        group=module.params["group"]
                     ),
                 )
                 if res.status_code != 200:

--- a/plugins/modules/purefa_dsrole.py
+++ b/plugins/modules/purefa_dsrole.py
@@ -189,7 +189,7 @@ def update_role(module, array):
                     names=[module.params["name"]],
                     directory_service_roles=DirectoryServiceRole(
                         group_base=module.params["group_base"],
-                        group=module.params["group"]
+                        group=module.params["group"],
                     ),
                 )
                 if res.status_code != 200:


### PR DESCRIPTION
##### SUMMARY
This change allows the module to update the default system-defined DS roles instead of trying to re-create them which is the current behavior. 

Fixes #672 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
[purefa_dsrole.py](https://github.com/Pure-Storage-Ansible/FlashArray-Collection/blob/5d741f8cc1b6bfa3de7eb5db347938b5e27ee7ac/plugins/modules/purefa_dsrole.py)

#### Example of Fixed Environment

Purity/FA version: 6.6.11
Ansible Collection: purestorage.flasharray: 1.32.0

Playbook Task Example
```
    - purestorage.flasharray.purefa_dsrole:
        role: "{{ item.role }}"
        group_base: "{{ item.group_base }}"
        group: "{{ item.group }}"
        fa_url: "{{ mgmt_vip }}"
        api_token: "{{ token }}"
      delegate_to: localhost
      loop:
        - group: 'Pure Array Admin'
          group_base: 'OU=Security Groups,OU=Groups'
          role: array_admin
        - group: 'Pure Ops Admin'
          group_base: 'OU=Security Groups,OU=Groups'
          role: ops_admin
        - group: 'Pure Read Only'
          group_base: 'OU=Security Groups,OU=Groups'
          role: readonly
        - group: 'Pure Storage Admin'
          group_base: 'OU=Security Groups,OU=Groups'
          role: storage_admin
```

Before:
```
failed: [pure -> localhost] (item={'group': 'Pure Array Admin', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'array_admin'}) => {"ansible_loop_var": "item", "changed": false, "item": {"group": "Pure Array Admin", "group_base": "OU=Security Groups,OU=Groups", "role": "array_admin"}, "msg": "Update Directory Service Role array_admin failed.Error: Cannot modify role for system-defined role mapping."}
failed: [pure -> localhost] (item={'group': 'Pure Ops Admin', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'ops_admin'}) => {"ansible_loop_var": "item", "changed": false, "item": {"group": "Pure Ops Admin", "group_base": "OU=Security Groups,OU=Groups", "role": "ops_admin"}, "msg": "Update Directory Service Role ops_admin failed.Error: Cannot modify role for system-defined role mapping."}
failed: [pure -> localhost] (item={'group': 'Pure Read Only', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'readonly'}) => {"ansible_loop_var": "item", "changed": false, "item": {"group": "Pure Read Only", "group_base": "OU=Security Groups,OU=Groups", "role": "readonly"}, "msg": "Update Directory Service Role readonly failed.Error: Cannot modify role for system-defined role mapping."}
failed: [pure -> localhost] (item={'group': 'Pure Storage Admin', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'storage_admin'}) => {"ansible_loop_var": "item", "changed": false, "item": {"group": "Pure Storage Admin", "group_base": "OU=Security Groups,OU=Groups", "role": "storage_admin"}, "msg": "Update Directory Service Role storage_admin failed.Error: Cannot modify role for system-defined role mapping."}
```

After:
```
changed: [pure -> localhost] => (item={'group': 'Pure Array Admin', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'array_admin'})
changed: [pure -> localhost] => (item={'group': 'Pure Ops Admin', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'ops_admin'})
changed: [pure -> localhost] => (item={'group': 'Pure Read Only', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'readonly'})
changed: [pure -> localhost] => (item={'group': 'Pure Storage Admin', 'group_base': 'OU=Security Groups,OU=Groups', 'role': 'storage_admin'})
```
