### PR TITLE
Add network performance data

### DIFF
--- a/changelogs/fragments/677_networ_perf.yaml
+++ b/changelogs/fragments/677_networ_perf.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+ - purefa_info - Add performance data for network interfaces
+ - purefa_info - Deprecate ``network.<interface>.slaves`` - replaced by ``network.<interface>.subinterfaces``
+ - purefa_info - Deprecate ``network.<interface>.hwaddr`` - replaced by ``network.<interface>.mac_address``


### PR DESCRIPTION
##### SUMMARY
Add network performance data to info module.
Deprecate `network.<interface>.slaves` - replaced by `network.<interface>.subinterfaces`
Deprecate `network.<interface>.hwaddr` - replaced by `network.<interface>.mac_address`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py