### PR TITLE
docs: fix typo in `plugins/doc_fragments/purestorage.py`

### DIFF
--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -37,10 +37,10 @@ options:
     default: false
     version_added: '1.29.0'
 notes:
-  - This module requires the C(purestorage) and C(py-pure-client) Python libraries
-  - Additional Python librarues may be required for specific modules.
+  - This module requires the C(purestorage) and C(py-pure-client) Python libraries.
+  - Additional Python libraries may be required for specific modules.
   - You must set C(PUREFA_URL) and C(PUREFA_API) environment variables
-    if I(fa_url) and I(api_token) arguments are not passed to the module directly
+    if I(fa_url) and I(api_token) arguments are not passed to the module directly.
 requirements:
   - python >= 3.3
   - purestorage >= 1.19


### PR DESCRIPTION
##### SUMMARY
Fix typo: librarues -> libraries
Fix punctuation: add periods after list lines to match the note at the top of [the module documentation](https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_info_module.html#ansible-collections-purestorage-flasharray-purefa-info-module)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Purestorage doc fragments
