### PR TITLE
Deprecate VNC feature

### DIFF
--- a/changelogs/fragments/684_no_vnc.yaml
+++ b/changelogs/fragments/684_no_vnc.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_vnc - VNC feature deprecated from Purity//FA 6.8.0.
+ - purefa_info - VNC feature deprecated from Purity//FA 6.8.0.

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -2549,7 +2549,10 @@ def generate_apps_dict(array):
         for app in range(0, len(app_nodes)):
             appname = app_nodes[app]["name"]
             apps_info[appname]["index"] = app_nodes[app]["index"]
-            apps_info[appname]["vnc"] = app_nodes[app]["vnc"]
+            if DSROLE_POLICY_API_VERSION in api_version:
+                apps_info[appname]["vnc"] = "Deprecated"
+            else:
+                apps_info[appname]["vnc"] = app_nodes[app]["vnc"]
     return apps_info
 
 

--- a/plugins/modules/purefa_vnc.py
+++ b/plugins/modules/purefa_vnc.py
@@ -86,12 +86,16 @@ try:
 except ImportError:
     HAS_PURESTORAGE = False
 
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa import (
     get_array,
     purefa_argument_spec,
 )
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
+)
+
+MAX_API_VERSION = "2.36"
 
 
 def enable_vnc(module, array, app):
@@ -157,7 +161,10 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     array = get_array(module)
-
+    api_version = array.get_rest_version()
+    if LooseVersion(MAX_API_VERSION) <= LooseVersion(api_version):
+        module.warn(msg="VNC feature deprecated from Purity//FA 6.8.0 and higher")
+        module.exit_json(changed=False)
     res = array.get_apps(names=[module.params["name"]])
     if res.status_code != 200:
         module.fail_json(

--- a/plugins/modules/purefa_vnc.py
+++ b/plugins/modules/purefa_vnc.py
@@ -163,7 +163,7 @@ def main():
     array = get_array(module)
     api_version = array.get_rest_version()
     if LooseVersion(MAX_API_VERSION) <= LooseVersion(api_version):
-        module.warn(msg="VNC feature deprecated from Purity//FA 6.8.0 and higher")
+        module.warn("VNC feature deprecated from Purity//FA 6.8.0 and higher")
         module.exit_json(changed=False)
     res = array.get_apps(names=[module.params["name"]])
     if res.status_code != 200:


### PR DESCRIPTION
##### SUMMARY
From Purity//FA 6.8.0 VNC feature for apps is deprecated as //RUN platform is transitioned to containers.
VNC module will raise a warning and fail cleanly if necessary
Info module will replace the VNC enabled boolean response with `"Deprecated"` as necessary

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_vnc.py
purefa_info.py