### PR TITLE
Update SMTP to RESTv2 and add new parameters

### DIFF
--- a/changelogs/fragments/693_update_smtp.yaml
+++ b/changelogs/fragments/693_update_smtp.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_smtp - Added support for additional parameters, including encryption mode and email prefixs and email sender name.


### PR DESCRIPTION
##### SUMMARY
Update module to use REST v2.
Add new parameters available from Prity//FA 6.6.7:

- `encryption_mode` - options are `starttls` or `""` to clear. 
- `sender`
- `subject_prefix`
-  `body_prefix`

##### ISSUE TYPE
- Feature Pull Request
- REST 2 Pull Request

##### COMPONENT NAME
purefa_smtp.py