### PR TITLE
Fix protocol endpoint check to cover all old REST versions

### DIFF
--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -493,7 +493,7 @@ def get_endpoint(module, name, array):
         res = array.get_volumes(names=[name])
     if res.status_code == 200:
         volume = list(res.items)[0]
-        if hasattr(volume.protocol_endpoint, "container_version"):
+        if volume.subtype == "protocol_endpoint":
             return volume
     return None
 


### PR DESCRIPTION
##### SUMMARY
Change value check to ensure protocol endpoints are correctly identified, even with old REST 2 versions, ie pre-2.16.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_volume.py