### PR TITLE
Allow LACP bonds as subnet interfaces

### DIFF
--- a/changelogs/fragments/718_lacp_subnet.yaml
+++ b/changelogs/fragments/718_lacp_subnet.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_vlan - Allow LACP bonds to be subnet interfaces

--- a/plugins/modules/purefa_vlan.py
+++ b/plugins/modules/purefa_vlan.py
@@ -118,12 +118,10 @@ def _get_subnet(module, array):
 
 def _get_interface(module, array):
     """Return Interface or None"""
-    if "ct" in module.params["name"]:
-        res = array.get_network_interfaces(names=[module.params["name"]])
-        if res.status_code != 200:
-            return None
-        return list(res.items)[0]
-    return None
+    res = array.get_network_interfaces(names=[module.params["name"]])
+    if res.status_code != 200:
+        return None
+    return list(res.items)[0]
 
 
 def _get_vif(array, interface, subnet):
@@ -206,7 +204,7 @@ def update_vif(module, array, interface, subnet):
     vif_info = _get_vif(array, interface, subnet)
     vif_name = vif_info["name"]
     if module.params["address"]:
-        if module.params["address"] != vif_info["address"]:
+        if module.params["address"] != vif_info["eth"]["address"]:
             changed = True
             if not module.check_mode:
                 res = array.patch_network_interfaces(


### PR DESCRIPTION
##### SUMMARY
Allow LACP bonds to be specified as subnet interfaces.
Fix issue with updating subnet.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_vlan.py