### PR TITLE
Fix empty group and group base in dsrole

### DIFF
--- a/changelogs/fragments/721_dsrole_bug.yaml
+++ b/changelogs/fragments/721_dsrole_bug.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_dsrole - Fixed bug with DS role having no group or group base cannot be updated

--- a/plugins/modules/purefa_dsrole.py
+++ b/plugins/modules/purefa_dsrole.py
@@ -158,8 +158,8 @@ def update_role(module, array):
         "readonly",
     ]:
         if (
-            role.group_base != module.params["group_base"]
-            or role.group != module.params["group"]
+            getattr(role, "group_base", None) != module.params["group_base"]
+            or getattr(role, "group", None) != module.params["group"]
             or role.role.name != module.params["role"]
         ):
             changed = True
@@ -180,8 +180,8 @@ def update_role(module, array):
                     )
     else:
         if (
-            role.group_base != module.params["group_base"]
-            or role.group != module.params["group"]
+            getattr(role, "group_base", None) != module.params["group_base"]
+            or getattr(role, "group", None) != module.params["group"]
         ):
             changed = True
             if not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Some directory services roles can be created without `group` or `group_base` values.
When trying to update these a crash will occur - this fixes the AttributeError issue

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_dsrole.yaml