### PR TITLE
Fix unneccessary requirement in SMTP module

### DIFF
--- a/plugins/modules/purefa_smtp.py
+++ b/plugins/modules/purefa_smtp.py
@@ -256,12 +256,10 @@ def main():
     )
 
     required_together = [["user", "password"]]
-    required_if = [["encryption_mode", "starttls", ["user", "password"]]]
-
+    
     module = AnsibleModule(
         argument_spec,
         required_together=required_together,
-        required_if=required_if,
         supports_check_mode=True,
     )
     if not HAS_PURESTORAGE:

--- a/plugins/modules/purefa_smtp.py
+++ b/plugins/modules/purefa_smtp.py
@@ -256,7 +256,6 @@ def main():
     )
 
     required_together = [["user", "password"]]
-    
     module = AnsibleModule(
         argument_spec,
         required_together=required_together,


### PR DESCRIPTION
##### SUMMARY
This removes an unnecessary `required_if` that is stopping legitimate SMTP configuration
Closes #727 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
purefa_smtp.py