### PR TITLE
PG version logic error

### DIFF
--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -1162,7 +1162,7 @@ def main():
     api_version = array.get_rest_version()
     if module.params["safe_mode"] and LooseVersion(
         RETENTION_LOCK_VERSION
-    ) <= LooseVersion(api_version):
+    ) > LooseVersion(api_version):
         module.fail_json(
             msg="API version does not support setting SafeMode on a protection group."
         )


### PR DESCRIPTION
##### SUMMARY
REST version check is inverted causing error when using `safe_mode` parameter.
Closes #726 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pg.py