### PR TITLE
Fix vgroup reporting for EG1 arrays

### DIFF
--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -2578,10 +2578,12 @@ def generate_vgroups_dict(module, array, performance):
             vgroups_info[name]["system"] = vgroups[vgroup].space.unique
             vgroups_info[name]["unique_space"] = vgroups[vgroup].space.unique
             vgroups_info[name]["virtual_space"] = vgroups[vgroup].space.virtual
-            vgroups_info[name]["data_reduction"] = vgroups[vgroup].space.data_reduction
-            vgroups_info[name]["total_reduction"] = vgroups[
-                vgroup
-            ].space.total_reduction
+            vgroups_info[name]["data_reduction"] = (
+                getattr(vgroups[vgroup].space, "data_reduction", None),
+            )
+            vgroups_info[name]["total_reduction"] = (
+                getattr(vgroups[vgroup].space, "total_reduction", None),
+            )
             vgroups_info[name]["total_provisioned"] = vgroups[
                 vgroup
             ].space.total_provisioned


### PR DESCRIPTION
##### SUMMARY
It appears that some data is not reported by EG1 arrays for volume groups, so we need to cater for this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py