### PR TITLE
Ensure expose_public_key is only used from the correct REST version

### DIFF
--- a/plugins/modules/purefa_user.py
+++ b/plugins/modules/purefa_user.py
@@ -160,6 +160,7 @@ EXPOSE_API_VERSION = "2.32"
 def get_user(module, array):
     """Return Local User Account or None"""
     user = None
+    api_version = array.get_rest_version()
     if LooseVersion(EXPOSE_API_VERSION) <= LooseVersion(api_version):
         res = array.get_admins(
             names=[module.params["name"]],

--- a/plugins/modules/purefa_user.py
+++ b/plugins/modules/purefa_user.py
@@ -135,7 +135,6 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
 HAS_PURESTORAGE = True
 try:
     from pypureclient.flasharray import AdminPost, AdminPatch, AdminRole
@@ -151,12 +150,23 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.purefa impo
 from ansible_collections.purestorage.flasharray.plugins.module_utils.common import (
     convert_time_to_millisecs,
 )
+from ansible_collections.purestorage.flasharray.plugins.module_utils.version import (
+    LooseVersion,
+)
+
+EXPOSE_API_VERSION = "2.32"
 
 
 def get_user(module, array):
     """Return Local User Account or None"""
     user = None
-    res = array.get_admins(names=[module.params["name"]], expose_public_key=True)
+    if LooseVersion(EXPOSE_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_admins(
+            names=[module.params["name"]],
+            expose_public_key=True,
+        )
+    else:
+        res = array.get_admins(names=[module.params["name"]])
     if res.status_code != 200:
         return None
     else:


### PR DESCRIPTION
##### SUMMARY
`expose_public_key` parameter only available from REST 2.32.
Add checks to ensure we don't call this on lower versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_user.py