### PR TITLE
Fix issue with deleting volumes without eradicate

### DIFF
--- a/changelogs/fragments/754_vol_delete.yaml
+++ b/changelogs/fragments/754_vol_delete.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_volume - Fixed issue for error on volume delete w/o eradicate


### PR DESCRIPTION
##### SUMMARY
Fix issue where trying to delete a volume without eradicate causes a failure 
```
line 1725, in delete_volume\nAttributeError: 'ValidResponse' object has no attribute 'errors'\n"
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_volume.py