### PR TITLE
Fix encrypted connections

### DIFF
--- a/changelogs/fragments/782_encrypt_connect.yaml
+++ b/changelogs/fragments/782_encrypt_connect.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+ - purefa_connect - Ensured that encrypted connections use encrypted connection keys
+minor_changes:
+ - purefa_connect - Allow asynchronous FC-based replication

--- a/plugins/modules/purefa_connect.py
+++ b/plugins/modules/purefa_connect.py
@@ -186,17 +186,11 @@ def create_connection(module, array):
             user_agent=user_agent,
         )
         connection_key = list(
-            remote_system.get_array_connections_connection_key().items
+            remote_system.get_array_connections_connection_key(
+                encrypted=module.params["encrypted"]
+            ).items
         )[0].connection_key
         remote_array = list(remote_system.get_arrays().items)[0].name
-        # TODO: Refactor when FC async is supported
-        if (
-            module.params["transport"].lower() == "fc"
-            and module.params["connection"].lower() == "async"
-        ):
-            module.fail_json(
-                msg="Asynchronous replication not supported using FC transport"
-            )
         if LooseVersion(ENCRYPT_VERSION) >= LooseVersion(api_version):
             if module.params["encrypted"]:
                 encrypted = "encrypted"


### PR DESCRIPTION
##### SUMMARY
Ensure that when selecting encrypted connectiosn, an encrypted connection key is used.
Also, allow FC async replication now.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_connect.py