### PR TITLE
Add context_names support to purefa_ntp

### DIFF
--- a/changelogs/fragments/792_fusion_ntp.yaml
+++ b/changelogs/fragments/792_fusion_ntp.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_ntp - Added Fusion support.


### PR DESCRIPTION
##### SUMMARY
Add `context` support to `purefa_ntp` so that NTP can be configured on a remote array.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_ntp.py
