### PR TITLE
Key Size issue with Import Cert

### DIFF
--- a/changelogs/fragments/818_cert_import.yaml
+++ b/changelogs/fragments/818_cert_import.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_certs - Resolved error with incorrect use of ``key_size`` for imported certificates

--- a/plugins/modules/purefa_certs.py
+++ b/plugins/modules/purefa_certs.py
@@ -336,7 +336,6 @@ def import_cert(module, array, reimport=False):
         certificate=module.params["certificate"],
         intermediate_certificate=module.params["intermeadiate_cert"],
         key=module.params["key"],
-        key_size=module.params["key_size"],
         passphrase=module.params["passphrase"],
         status="imported",
     )


### PR DESCRIPTION
##### SUMMARY
`key_size` is not required for importing of keys, leading to an import failure.
Closes #817 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_certs.py