### PR TITLE
Address Issues Found in purefa_network.py

### DIFF
--- a/changelogs/fragments/851_network_interface.yaml
+++ b/changelogs/fragments/851_network_interface.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_network.py - Addressed issues found in update_interface

--- a/plugins/modules/purefa_network.py
+++ b/plugins/modules/purefa_network.py
@@ -345,7 +345,7 @@ def update_interface(module, array):
         "services": sorted(interface["services"]),
         "subinterfaces": sorted(interface.eth.subinterfaces),
     }
-    new_state = current_state
+    new_state = current_state.copy()
     if module.params["subinterfaces"]:
         new_subinterfaces = _check_subinterfaces(module, array)
         if new_subinterfaces != current_state["subinterfaces"]:
@@ -367,8 +367,9 @@ def update_interface(module, array):
             current_state["gateway"] = None
         else:
             current_state["gateway"] = None
-    if module.params["servicelist"] and sorted(
-        module.params["servicelist"] != current_state["services"]
+    if (
+        module.params["servicelist"]
+        and sorted(module.params["servicelist"]) != current_state["services"]
     ):
         new_state["services"] = sorted(module.params["servicelist"])
     if (
@@ -410,7 +411,7 @@ def update_interface(module, array):
             new_state["netmask"] = None
     if module.params["gateway"] and module.params["gateway"] in ["0.0.0.0", "::"]:
         new_state["gateway"] = None
-    elif valid_ipv4(new_state["address"]):
+    elif new_state["address"] and valid_ipv4(new_state["address"]):
         cidr = str(IPAddress(new_state["netmask"]).netmask_bits())
         full_addr = new_state["address"] + "/" + cidr
         if module.params["gateway"] not in IPNetwork(full_addr):


### PR DESCRIPTION


##### SUMMARY
This PR contains 3 items that needed to be fixed in order for me to run the module in the same manner as I was before the current version of the collection. 

1. Without `current_state.copy()` on `new_state = current_state`, you will be updating `current_state` every time you change `new_state` so changes will never be pushed due to `if new_state != current_state:`.

2. The logic for validating `servicelist` argument was broken as the code tried to sort a bool. 

3. Also, if you are not providing an address then `elif valid_ipv4(new_state["address"]):` will fail so you need to validate an address is provided beforehand. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/purefa_network.py

##### ADDITIONAL INFORMATION
This was required in order to make changes to servicelist without an address on the physical interface.
Example:
```
- name: Configure and enable iSCSI network interfaces
  purestorage.flasharray.purefa_network:
    name: "{{ item }}"
    mtu: 9000
    servicelist:
      - iscsi
    state: present
    fa_url: "{{ mgmt_vip }}"
    api_token: "{{ token }}"
  delegate_to: localhost
  loop: "{{ iscsi_ports }}"
```
