### PR TITLE
Upgrade GitHub Actions versions in ansible-lint workflow

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -10,7 +10,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-          
       - name: Run ansible-lint
         uses: ansible/ansible-lint@main
         with:


### PR DESCRIPTION
Updated actions/checkout and actions/setup-python versions.

Required until https://github.com/ansible/ansible-lint/pull/4829 is merged
