### PR TITLE
Add CA for SMB

### DIFF
--- a/changelogs/fragments/863_smb_ca.yaml
+++ b/changelogs/fragments/863_smb_ca.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_policy - Added Continuous Availability support for SMB policies


### PR DESCRIPTION
##### SUMMARY
Add parameter `continuous_availability` to set status of CA on SMB policies from REST 2.43

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_policy.py