### PR TITLE
Fix for uptime with shelves

### DIFF
--- a/changelogs/fragments/887_shelf_uptime.yaml
+++ b/changelogs/fragments/887_shelf_uptime.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_info - Fixed issue with shelf controllers not supporting uptime

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -182,7 +182,9 @@ def generate_default_dict(array):
                 default_info["safe_mode"] = "Enabled"
         if LooseVersion(UPTIME_API_VERSION) <= LooseVersion(api_version):
             default_info["controller_uptime"] = []
-            controllers = list(array.get_controllers().items)
+            controllers = list(
+                array.get_controllers(filter="type='array_controller'").items
+            )
             timenow = datetime.fromtimestamp(time.time())
             for controller in range(0, len(controllers)):
                 boottime = datetime.fromtimestamp(


### PR DESCRIPTION
##### SUMMARY
Fix for info module where shelf controllers exist. These have no uptime so were crashing the module.
Select only array controllers for uptime calculation.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py