### PR TITLE
fix(purefa_certs): Fix update_cert object reference bug and add tests

### DIFF
--- a/plugins/modules/purefa_certs.py
+++ b/plugins/modules/purefa_certs.py
@@ -210,68 +210,64 @@ def update_cert(module, array):
     """Update existing SSL Certificate"""
     changed = False
     current_cert = list(array.get_certificates(names=[module.params["name"]]).items)[0]
-    new_cert = current_cert
-    if module.params["common_name"] and module.params["common_name"] != getattr(
-        current_cert, "common_name", None
-    ):
-        new_cert.common_name = module.params["common_name"]
-    else:
-        new_cert.common_name = getattr(current_cert, "common_name", None)
-    if module.params["country"] and module.params["country"] != getattr(
-        current_cert, "country", None
-    ):
-        new_cert.country = module.params["country"]
-    else:
-        new_cert.country = getattr(current_cert, "country")
-    if module.params["email"] and module.params["email"] != getattr(
-        current_cert, "email", None
-    ):
-        new_cert.email = module.params["email"]
-    else:
-        new_cert.email = getattr(current_cert, "email", None)
-    if module.params["key_size"] and module.params["key_size"] != getattr(
-        current_cert, "key_size", None
-    ):
-        new_cert.key_size = module.params["key_size"]
-    else:
-        new_cert.key_size = getattr(current_cert, "key_size", None)
-    if module.params["locality"] and module.params["locality"] != getattr(
-        current_cert, "locality", None
-    ):
-        new_cert.locality = module.params["locality"]
-    else:
-        new_cert.locality = getattr(current_cert, "locality", None)
-    if module.params["province"] and module.params["province"] != getattr(
-        current_cert, "state", None
-    ):
-        new_cert.state = module.params["province"]
-    else:
-        new_cert.state = getattr(current_cert, "state", None)
-    if module.params["organization"] and module.params["organization"] != getattr(
-        current_cert, "organization", None
-    ):
-        new_cert.organization = module.params["organization"]
-    else:
-        new_cert.organization = getattr(current_cert, "organization", None)
-    if module.params["org_unit"] and module.params["org_unit"] != getattr(
-        current_cert, "organizational_unit", None
-    ):
-        new_cert.organizational_unit = module.params["org_unit"]
-    else:
-        new_cert.organizational_unit = getattr(
-            current_cert, "organizational_unit", None
-        )
-    if new_cert != current_cert:
+
+    # Build new values, tracking if any changes are needed
+    new_common_name = getattr(current_cert, "common_name", None)
+    if module.params["common_name"] and module.params["common_name"] != new_common_name:
+        new_common_name = module.params["common_name"]
         changed = True
+
+    new_country = getattr(current_cert, "country", None)
+    if module.params["country"] and module.params["country"] != new_country:
+        new_country = module.params["country"]
+        changed = True
+
+    new_email = getattr(current_cert, "email", None)
+    if module.params["email"] and module.params["email"] != new_email:
+        new_email = module.params["email"]
+        changed = True
+
+    new_key_size = getattr(current_cert, "key_size", None)
+    if module.params["key_size"] and module.params["key_size"] != new_key_size:
+        new_key_size = module.params["key_size"]
+        changed = True
+
+    new_locality = getattr(current_cert, "locality", None)
+    if module.params["locality"] and module.params["locality"] != new_locality:
+        new_locality = module.params["locality"]
+        changed = True
+
+    new_state = getattr(current_cert, "state", None)
+    if module.params["province"] and module.params["province"] != new_state:
+        new_state = module.params["province"]
+        changed = True
+
+    new_organization = getattr(current_cert, "organization", None)
+    if (
+        module.params["organization"]
+        and module.params["organization"] != new_organization
+    ):
+        new_organization = module.params["organization"]
+        changed = True
+
+    new_organizational_unit = getattr(current_cert, "organizational_unit", None)
+    if (
+        module.params["org_unit"]
+        and module.params["org_unit"] != new_organizational_unit
+    ):
+        new_organizational_unit = module.params["org_unit"]
+        changed = True
+
+    if changed:
         certificate = flasharray.CertificatePost(
-            common_name=new_cert.common_name,
-            country=getattr(new_cert, "country", None),
-            email=getattr(new_cert, "email", None),
-            key_size=getattr(new_cert, "key_size", None),
-            locality=getattr(new_cert, "locality", None),
-            organization=getattr(new_cert, "organization", None),
-            organizational_unit=getattr(new_cert, "organizational_unit", None),
-            state=getattr(new_cert, "state", None),
+            common_name=new_common_name,
+            country=new_country,
+            email=new_email,
+            key_size=new_key_size,
+            locality=new_locality,
+            organization=new_organization,
+            organizational_unit=new_organizational_unit,
+            state=new_state,
         )
         if not module.check_mode:
             res = array.patch_certificates(

--- a/tests/unit/plugins/modules/test_purefa_ds.py
+++ b/tests/unit/plugins/modules/test_purefa_ds.py
@@ -148,3 +148,225 @@ class TestDeleteDsExtended:
         delete_ds(mock_module, mock_array)
 
         mock_module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestUpdateDs:
+    """Tests for update_ds function"""
+
+    @patch("plugins.modules.purefa_ds.check_response")
+    @patch("plugins.modules.purefa_ds.get_with_context")
+    def test_update_ds_no_changes(self, mock_get_with_context, mock_check_response):
+        """Test update_ds when no changes needed"""
+        mock_module = Mock()
+        mock_module.params = {
+            "dstype": "management",
+            "context": "",
+            "uri": None,
+            "base_dn": None,
+            "enable": True,
+            "bind_user": None,
+            "bind_password": None,
+            "force_bind_password": False,
+            "certificate": None,
+            "check_peer": False,
+            "user_object": None,
+            "user_login": None,
+        }
+        mock_module.check_mode = False
+        mock_array = Mock()
+
+        # Create mock current directory service
+        mock_ds = Mock()
+        mock_ds.name = "management"
+        mock_ds.uris = ["ldap://test.example.com"]
+        mock_ds.base_dn = "DC=example,DC=com"
+        mock_ds.bind_user = "admin"
+        mock_ds.enabled = True
+        mock_ds.check_peer = False
+        mock_ds.ca_certificate = None
+        mock_ds.management = Mock()
+        mock_ds.management.user_login_attribute = "sAMAccountName"
+        mock_ds.management.user_object_class = "User"
+        mock_get_with_context.return_value = Mock(items=[mock_ds])
+
+        from plugins.modules.purefa_ds import update_ds
+
+        update_ds(mock_module, mock_array)
+
+        mock_module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_ds.DirectoryService")
+    @patch("plugins.modules.purefa_ds.DirectoryServiceManagement")
+    @patch("plugins.modules.purefa_ds.check_response")
+    @patch("plugins.modules.purefa_ds.get_with_context")
+    def test_update_ds_uri_change(
+        self,
+        mock_get_with_context,
+        mock_check_response,
+        mock_ds_mgmt,
+        mock_ds_class,
+    ):
+        """Test update_ds when URI changes"""
+        mock_module = Mock()
+        mock_module.params = {
+            "dstype": "management",
+            "context": "",
+            "uri": ["ldap://new.example.com"],
+            "base_dn": None,
+            "enable": True,
+            "bind_user": "admin",
+            "bind_password": "newpassword",
+            "force_bind_password": True,
+            "certificate": None,
+            "check_peer": False,
+            "user_object": None,
+            "user_login": None,
+        }
+        mock_module.check_mode = False
+        mock_array = Mock()
+
+        # Create mock current directory service
+        mock_ds = Mock()
+        mock_ds.name = "management"
+        mock_ds.uris = ["ldap://old.example.com"]
+        mock_ds.base_dn = "DC=example,DC=com"
+        mock_ds.bind_user = "admin"
+        mock_ds.enabled = True
+        mock_ds.check_peer = False
+        mock_ds.ca_certificate = None
+        mock_ds.management = Mock()
+        mock_ds.management.user_login_attribute = "sAMAccountName"
+        mock_ds.management.user_object_class = "User"
+        mock_get_with_context.return_value = Mock(items=[mock_ds], status_code=200)
+
+        from plugins.modules.purefa_ds import update_ds
+
+        update_ds(mock_module, mock_array)
+
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_ds.DirectoryService")
+    @patch("plugins.modules.purefa_ds.check_response")
+    @patch("plugins.modules.purefa_ds.get_with_context")
+    def test_update_ds_data_type(
+        self, mock_get_with_context, mock_check_response, mock_ds_class
+    ):
+        """Test update_ds for data directory service type"""
+        mock_module = Mock()
+        mock_module.params = {
+            "dstype": "data",
+            "context": "",
+            "uri": ["ldap://data.example.com"],
+            "base_dn": "DC=data,DC=com",
+            "enable": True,
+            "bind_user": "dataadmin",
+            "bind_password": "datapassword",
+            "force_bind_password": True,
+            "certificate": None,
+            "check_peer": False,
+            "user_object": None,
+            "user_login": None,
+        }
+        mock_module.check_mode = False
+        mock_array = Mock()
+
+        # Create mock current directory service - data type
+        mock_ds = Mock()
+        mock_ds.name = "data"
+        mock_ds.uris = None
+        mock_ds.base_dn = None
+        mock_ds.bind_user = None
+        mock_ds.enabled = False
+        mock_ds.check_peer = False
+        mock_get_with_context.return_value = Mock(items=[mock_ds], status_code=200)
+
+        from plugins.modules.purefa_ds import update_ds
+
+        update_ds(mock_module, mock_array)
+
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_update_ds_check_mode(self):
+        """Test update_ds in check mode"""
+        mock_module = Mock()
+        mock_module.params = {
+            "dstype": "management",
+            "context": "",
+            "uri": ["ldap://new.example.com"],
+            "base_dn": "DC=new,DC=com",
+            "enable": True,
+            "bind_user": "newadmin",
+            "bind_password": "newpassword",
+            "force_bind_password": True,
+            "certificate": None,
+            "check_peer": False,
+            "user_object": None,
+            "user_login": None,
+        }
+        mock_module.check_mode = True
+        mock_array = Mock()
+
+        # Create mock current directory service
+        mock_ds = Mock()
+        mock_ds.name = "management"
+        mock_ds.uris = ["ldap://old.example.com"]
+        mock_ds.base_dn = "DC=old,DC=com"
+        mock_ds.bind_user = "oldadmin"
+        mock_ds.enabled = False
+        mock_ds.check_peer = False
+        mock_ds.ca_certificate = None
+        mock_ds.management = Mock()
+        mock_ds.management.user_login_attribute = "sAMAccountName"
+        mock_ds.management.user_object_class = "User"
+
+        with patch("plugins.modules.purefa_ds.get_with_context") as mock_get:
+            mock_get.return_value = Mock(items=[mock_ds])
+            from plugins.modules.purefa_ds import update_ds
+
+            update_ds(mock_module, mock_array)
+
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_ds.get_with_context")
+    def test_update_ds_missing_bind_password(self, mock_get_with_context):
+        """Test update_ds fails when bind_password is required but not provided"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.params = {
+            "dstype": "management",
+            "context": "",
+            "uri": ["ldap://new.example.com"],
+            "base_dn": None,
+            "enable": True,
+            "bind_user": "newadmin",
+            "bind_password": None,
+            "force_bind_password": True,
+            "certificate": None,
+            "check_peer": False,
+            "user_object": None,
+            "user_login": None,
+        }
+        mock_module.check_mode = False
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_array = Mock()
+
+        mock_ds = Mock()
+        mock_ds.name = "management"
+        mock_ds.uris = ["ldap://old.example.com"]
+        mock_ds.bind_user = "oldadmin"
+        mock_ds.enabled = True
+        mock_ds.check_peer = False
+        mock_ds.ca_certificate = None
+        mock_ds.management = Mock()
+        mock_ds.management.user_login_attribute = "sAMAccountName"
+        mock_ds.management.user_object_class = "User"
+        mock_get_with_context.return_value = Mock(items=[mock_ds])
+
+        from plugins.modules.purefa_ds import update_ds
+
+        with pytest.raises(SystemExit):
+            update_ds(mock_module, mock_array)
+
+        mock_module.fail_json.assert_called_once()
+        assert "bind_password" in mock_module.fail_json.call_args[1]["msg"]


### PR DESCRIPTION
##### SUMMARY
- Fixed bug where new_cert = current_cert created same object reference
- The comparison new_cert != current_cert always returned False
- Refactored to track changes explicitly with separate variables
- Added 9 new tests for purefa_certs covering create, update, delete, import
- Added 5 new tests for purefa_ds covering update_ds scenarios
- Added 9 new tests for purefa_ad covering create, update, delete

##### COMPONENT NAME
purefa_cert.py