### PR TITLE
refactor: Apply api_helpers to purefa_pod_replica and purefa_directory

### DIFF
--- a/tests/unit/plugins/modules/test_purefa_pod_replica.py
+++ b/tests/unit/plugins/modules/test_purefa_pod_replica.py
@@ -38,15 +38,9 @@ sys.modules[
 sys.modules[
     "ansible_collections.purestorage.flasharray.plugins.module_utils.error_handlers"
 ] = MagicMock()
-
-# Create a mock version module with real LooseVersion
-mock_version_module = MagicMock()
-from packaging.version import Version as LooseVersion
-
-mock_version_module.LooseVersion = LooseVersion
 sys.modules[
     "ansible_collections.purestorage.flasharray.plugins.module_utils.version"
-] = mock_version_module
+] = MagicMock()
 
 from plugins.modules.purefa_pod_replica import (
     get_local_pod,
@@ -60,31 +54,28 @@ from plugins.modules.purefa_pod_replica import (
 class TestGetLocalPod:
     """Test cases for get_local_pod function"""
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion")
-    def test_get_local_pod_exists(self, mock_loose_version):
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_get_local_pod_exists(self, mock_get):
         """Test get_local_pod returns pod when it exists"""
-        mock_loose_version.side_effect = lambda x: float(x) if x != "2.38" else 2.38
         mock_module = Mock()
         mock_module.params = {"name": "test-pod", "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
         mock_pod = Mock()
         mock_pod.name = "test-pod"
-        mock_array.get_pods.return_value = Mock(status_code=200, items=[mock_pod])
+        mock_get.return_value = Mock(status_code=200, items=[mock_pod])
 
         result = get_local_pod(mock_module, mock_array)
 
         assert result == mock_pod
+        mock_get.assert_called_once()
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion")
-    def test_get_local_pod_not_exists(self, mock_loose_version):
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_get_local_pod_not_exists(self, mock_get):
         """Test get_local_pod returns None when pod doesn't exist"""
-        mock_loose_version.side_effect = lambda x: float(x) if x != "2.38" else 2.38
         mock_module = Mock()
         mock_module.params = {"name": "nonexistent", "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.get_pods.return_value = Mock(status_code=404, items=[])
+        mock_get.return_value = Mock(status_code=404, items=[])
 
         result = get_local_pod(mock_module, mock_array)
 
@@ -94,17 +85,13 @@ class TestGetLocalPod:
 class TestGetLocalRl:
     """Test cases for get_local_rl function"""
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion")
-    def test_get_local_rl_not_exists(self, mock_loose_version):
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_get_local_rl_not_exists(self, mock_get):
         """Test get_local_rl returns None when replica link doesn't exist"""
-        mock_loose_version.side_effect = lambda x: float(x) if x != "2.38" else 2.38
         mock_module = Mock()
         mock_module.params = {"name": "test-pod", "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.get_pod_replica_links.return_value = Mock(
-            total_item_count=0, items=[]
-        )
+        mock_get.return_value = Mock(total_item_count=0, items=[])
 
         result = get_local_rl(mock_module, mock_array)
 
@@ -114,66 +101,64 @@ class TestGetLocalRl:
 class TestDeleteRl:
     """Test cases for delete_rl function"""
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion")
-    def test_delete_rl_check_mode(self, mock_loose_version):
+    @patch("plugins.modules.purefa_pod_replica.delete_with_context")
+    def test_delete_rl_check_mode(self, mock_delete):
         """Test delete_rl in check mode"""
-        mock_loose_version.side_effect = lambda x: float(x) if x != "2.38" else 2.38
         mock_module = Mock()
         mock_module.check_mode = True
         mock_module.params = {"name": "test-pod", "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
         mock_rl = Mock()
 
         delete_rl(mock_module, mock_array, mock_rl)
 
         mock_module.exit_json.assert_called_once_with(changed=True)
+        mock_delete.assert_not_called()
 
 
 class TestUpdateRl:
     """Test cases for update_rl function"""
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_update_rl_no_pause_param(self, mock_lv):
+    @patch("plugins.modules.purefa_pod_replica.patch_with_context")
+    def test_update_rl_no_pause_param(self, mock_patch):
         """Test update_rl when pause is None - no change"""
         mock_module = Mock()
         mock_module.check_mode = False
         mock_module.params = {"name": "test-pod", "pause": None, "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
         mock_rl = Mock()
         mock_rl.status = "replicating"
 
         update_rl(mock_module, mock_array, mock_rl)
 
         mock_module.exit_json.assert_called_once_with(changed=False)
+        mock_patch.assert_not_called()
 
     @patch("plugins.modules.purefa_pod_replica.check_response")
     @patch("plugins.modules.purefa_pod_replica.PodReplicaLinkPatch")
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_update_rl_pause_success(self, mock_lv, mock_patch, mock_check_response):
+    @patch("plugins.modules.purefa_pod_replica.patch_with_context")
+    def test_update_rl_pause_success(self, mock_patch, mock_rl_patch, mock_check):
         """Test update_rl pausing a replica link"""
         mock_module = Mock()
         mock_module.check_mode = False
         mock_module.params = {"name": "test-pod", "pause": True, "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.patch_pod_replica_links.return_value = Mock(status_code=200)
+        mock_patch.return_value = Mock(status_code=200)
         mock_rl = Mock()
         mock_rl.status = "replicating"
         mock_rl.__getitem__ = Mock(return_value={"name": "remote-pod"})
 
         update_rl(mock_module, mock_array, mock_rl)
 
-        mock_array.patch_pod_replica_links.assert_called_once()
+        mock_patch.assert_called_once()
         mock_module.exit_json.assert_called_once_with(changed=True)
 
 
 class TestCreateRl:
     """Test cases for create_rl function"""
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_create_rl_missing_target_pod(self, mock_lv):
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_create_rl_missing_target_pod(self, mock_get):
         """Test create_rl fails without target_pod"""
         import pytest
 
@@ -187,15 +172,14 @@ class TestCreateRl:
         }
         mock_module.fail_json.side_effect = SystemExit(1)
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
 
         with pytest.raises(SystemExit):
             create_rl(mock_module, mock_array)
 
         mock_module.fail_json.assert_called_once()
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_create_rl_missing_target_array(self, mock_lv):
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_create_rl_missing_target_array(self, mock_get):
         """Test create_rl fails without target_array"""
         import pytest
 
@@ -209,15 +193,14 @@ class TestCreateRl:
         }
         mock_module.fail_json.side_effect = SystemExit(1)
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
 
         with pytest.raises(SystemExit):
             create_rl(mock_module, mock_array)
 
         mock_module.fail_json.assert_called_once()
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_create_rl_no_connected_arrays(self, mock_lv):
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_create_rl_no_connected_arrays(self, mock_get):
         """Test create_rl fails when no arrays are connected"""
         import pytest
 
@@ -231,7 +214,6 @@ class TestCreateRl:
         }
         mock_module.fail_json.side_effect = SystemExit(1)
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
         mock_array.get_array_connections.return_value = Mock(total_item_count=0)
 
         with pytest.raises(SystemExit):
@@ -240,8 +222,9 @@ class TestCreateRl:
         mock_module.fail_json.assert_called_once()
 
     @patch("plugins.modules.purefa_pod_replica.check_response")
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_create_rl_success(self, mock_lv, mock_check_response):
+    @patch("plugins.modules.purefa_pod_replica.post_with_context")
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_create_rl_success(self, mock_get, mock_post, mock_check):
         """Test create_rl successfully creates replica link"""
         mock_module = Mock()
         mock_module.check_mode = False
@@ -252,22 +235,20 @@ class TestCreateRl:
             "context": "",
         }
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.get_array_connections.return_value = Mock(
-            total_item_count=1,
-            status_code=200,
-            items=[Mock(status="connected")],
-        )
-        mock_array.post_pod_replica_links.return_value = Mock(status_code=200)
+        # Direct call for total_item_count check
+        mock_array.get_array_connections.return_value = Mock(total_item_count=1)
+        # get_with_context returns the actual connection
+        mock_get.return_value = Mock(status_code=200, items=[Mock(status="connected")])
+        mock_post.return_value = Mock(status_code=200)
 
         create_rl(mock_module, mock_array)
 
-        mock_array.post_pod_replica_links.assert_called_once()
+        mock_post.assert_called_once()
         mock_module.exit_json.assert_called_once_with(changed=True)
 
-    @patch("plugins.modules.purefa_pod_replica.check_response")
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_create_rl_check_mode(self, mock_lv, mock_check_response):
+    @patch("plugins.modules.purefa_pod_replica.post_with_context")
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_create_rl_check_mode(self, mock_get, mock_post):
         """Test create_rl in check mode"""
         mock_module = Mock()
         mock_module.check_mode = True
@@ -278,21 +259,18 @@ class TestCreateRl:
             "context": "",
         }
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.get_array_connections.return_value = Mock(
-            total_item_count=1,
-            status_code=200,
-            items=[Mock(status="connected")],
-        )
+        # Direct call for total_item_count check
+        mock_array.get_array_connections.return_value = Mock(total_item_count=1)
+        # get_with_context returns the actual connection
+        mock_get.return_value = Mock(status_code=200, items=[Mock(status="connected")])
 
         create_rl(mock_module, mock_array)
 
-        mock_array.post_pod_replica_links.assert_not_called()
+        mock_post.assert_not_called()
         mock_module.exit_json.assert_called_once_with(changed=True)
 
-    @patch("plugins.modules.purefa_pod_replica.check_response")
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_create_rl_bad_status(self, mock_lv, mock_check_response):
+    @patch("plugins.modules.purefa_pod_replica.get_with_context")
+    def test_create_rl_bad_status(self, mock_get):
         """Test create_rl fails with bad connection status"""
         import pytest
 
@@ -306,11 +284,11 @@ class TestCreateRl:
         }
         mock_module.fail_json.side_effect = SystemExit(1)
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.get_array_connections.return_value = Mock(
-            total_item_count=1,
-            status_code=200,
-            items=[Mock(status="disconnected")],
+        # Direct call for total_item_count check
+        mock_array.get_array_connections.return_value = Mock(total_item_count=1)
+        # get_with_context returns connection with bad status
+        mock_get.return_value = Mock(
+            status_code=200, items=[Mock(status="disconnected")]
         )
 
         with pytest.raises(SystemExit):
@@ -324,21 +302,20 @@ class TestDeleteRlSuccess:
     """Test cases for delete_rl success paths"""
 
     @patch("plugins.modules.purefa_pod_replica.check_response")
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_delete_rl_success(self, mock_lv, mock_check_response):
+    @patch("plugins.modules.purefa_pod_replica.delete_with_context")
+    def test_delete_rl_success(self, mock_delete, mock_check):
         """Test delete_rl successfully deletes"""
         mock_module = Mock()
         mock_module.check_mode = False
         mock_module.params = {"name": "test-pod", "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.delete_pod_replica_links.return_value = Mock(status_code=200)
+        mock_delete.return_value = Mock(status_code=200)
         mock_rl = Mock()
         mock_rl.__getitem__ = Mock(return_value={"name": "remote-pod"})
 
         delete_rl(mock_module, mock_array, mock_rl)
 
-        mock_array.delete_pod_replica_links.assert_called_once()
+        mock_delete.assert_called_once()
         mock_module.exit_json.assert_called_once_with(changed=True)
 
 
@@ -347,52 +324,49 @@ class TestUpdateRlSuccess:
 
     @patch("plugins.modules.purefa_pod_replica.check_response")
     @patch("plugins.modules.purefa_pod_replica.PodReplicaLinkPatch")
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_update_rl_resume_success(self, mock_lv, mock_patch, mock_check_response):
+    @patch("plugins.modules.purefa_pod_replica.patch_with_context")
+    def test_update_rl_resume_success(self, mock_patch, mock_rl_patch, mock_check):
         """Test update_rl resuming a paused replica link"""
         mock_module = Mock()
         mock_module.check_mode = False
         mock_module.params = {"name": "test-pod", "pause": False, "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
-        mock_array.patch_pod_replica_links.return_value = Mock(status_code=200)
+        mock_patch.return_value = Mock(status_code=200)
         mock_rl = Mock()
         mock_rl.status = "paused"
         mock_rl.__getitem__ = Mock(return_value={"name": "remote-pod"})
 
         update_rl(mock_module, mock_array, mock_rl)
 
-        mock_array.patch_pod_replica_links.assert_called_once()
+        mock_patch.assert_called_once()
         mock_module.exit_json.assert_called_once_with(changed=True)
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_update_rl_already_paused(self, mock_lv):
+    @patch("plugins.modules.purefa_pod_replica.patch_with_context")
+    def test_update_rl_already_paused(self, mock_patch):
         """Test update_rl when already paused - no change"""
         mock_module = Mock()
         mock_module.check_mode = False
         mock_module.params = {"name": "test-pod", "pause": True, "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
         mock_rl = Mock()
         mock_rl.status = "paused"
 
         update_rl(mock_module, mock_array, mock_rl)
 
-        mock_array.patch_pod_replica_links.assert_not_called()
+        mock_patch.assert_not_called()
         mock_module.exit_json.assert_called_once_with(changed=False)
 
-    @patch("plugins.modules.purefa_pod_replica.LooseVersion", side_effect=LooseVersion)
-    def test_update_rl_already_running(self, mock_lv):
+    @patch("plugins.modules.purefa_pod_replica.patch_with_context")
+    def test_update_rl_already_running(self, mock_patch):
         """Test update_rl when already running - no change"""
         mock_module = Mock()
         mock_module.check_mode = False
         mock_module.params = {"name": "test-pod", "pause": False, "context": ""}
         mock_array = Mock()
-        mock_array.get_rest_version.return_value = "2.38"
         mock_rl = Mock()
         mock_rl.status = "replicating"
 
         update_rl(mock_module, mock_array, mock_rl)
 
-        mock_array.patch_pod_replica_links.assert_not_called()
+        mock_patch.assert_not_called()
         mock_module.exit_json.assert_called_once_with(changed=False)


### PR DESCRIPTION
##### SUMMARY
Refactored the final 2 modules to use centralized API helper functions from api_helpers.py, eliminating 15 duplicated CONTEXT_VERSION patterns.

##### ISSUE TYPE
- Refactor Pull Request

##### COMPONENT NAME
purefa_pod_replica.py
purefa_directory.py