### PR TITLE
Add nfs_version parameter to PolicyrulenfsclientpostRules

### DIFF
--- a/changelogs/fragments/996_purefa_policy_nfs_version.yml
+++ b/changelogs/fragments/996_purefa_policy_nfs_version.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - purefa_policy - Fixed ``Versions options must be the same for all NFS export policy rules`` when adding multiple clients to an existing NFS policy by adding missing ``nfs_version`` parameter to ``PolicyrulenfsclientpostRules`` in ``update_policy()`` for API >= 2.29
+  - purefa_policy - Fixed ``Versions options must be the same for all NFS export policy rules`` when adding multiple clients to an existing NFS policy by adding missing ``nfs_version`` parameter

--- a/changelogs/fragments/996_purefa_policy_nfs_version.yml
+++ b/changelogs/fragments/996_purefa_policy_nfs_version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefa_policy - Fixed ``Versions options must be the same for all NFS export policy rules`` when adding multiple clients to an existing NFS policy by adding missing ``nfs_version`` parameter to ``PolicyrulenfsclientpostRules`` in ``update_policy()`` for API >= 2.29

--- a/plugins/modules/purefa_policy.py
+++ b/plugins/modules/purefa_policy.py
@@ -1466,6 +1466,7 @@ def update_policy(module, array, api_version, all_squash):
                                     client=module.params["client"],
                                     access=module.params["nfs_access"],
                                     security=module.params["security"],
+                                    nfs_version=module.params["nfs_version"],
                                 )
                         else:
                             if all_squash:
@@ -1482,6 +1483,7 @@ def update_policy(module, array, api_version, all_squash):
                                     permission=module.params["nfs_permission"],
                                     client=module.params["client"],
                                     access=module.params["nfs_access"],
+                                    nfs_version=module.params["nfs_version"],
                                 )
                     rule = PolicyRuleNfsClientPost(rules=[rules])
                     changed_rule = True


### PR DESCRIPTION
##### SUMMARY
Fix missing `nfs_version` parameter in `update_policy()` for NFS client rules when adding additional clients to an existing NFS export policy with API >= 2.29.

In `update_policy()`, the `else` branch (API >= `SECURITY_VERSION` 2.29, `all_squash=False`) was building `PolicyrulenfsclientpostRules` without passing `nfs_version` in two cases:
- when `security` is set but `all_squash` is `False`
- when neither `security` nor `all_squash` is set

This caused the FlashArray API to return: `Versions options must be the same for all NFS export policy rules` when looping over multiple clients for an existing policy that already had `nfs_version` set.

Fixes #996 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_policy

##### ADDITIONAL INFORMATION
Bug fixed by copilot
