### PR TITLE
Update protocol removal notice in purefa_host.py

### DIFF
--- a/plugins/modules/purefa_host.py
+++ b/plugins/modules/purefa_host.py
@@ -1313,7 +1313,7 @@ def main():
             protocol=dict(
                 type="str",
                 choices=["fc", "iscsi", "nvme", "mixed"],
-                removed_from_collection="1.13",
+                removed_from_collection="purestorage.flasharray",
                 removed_in_version="2.0.0",
             ),
             nqn=dict(type="list", elements="str"),


### PR DESCRIPTION
##### SUMMARY

Problem
=======

Users running ansible-core 2.19 or later receive the following error when using the `purefa_host` module with the `protocol` parameter:

`Task failed: Module failed: collection_name must consist of two non-keyword identifiers separated by '.'`

Root Cause
=======

In `plugins/modules/purefa_host.py`, the `protocol` parameter in the `argument_spec` has an incorrectly set `removed_from_collection` value:
```
protocol=dict(
    type="str",
    choices=["fc", "iscsi", "nvme", "mixed"],
    removed_from_collection="1.13",   # <-- wrong: this is a version number, not a collection name
    removed_in_version="2.0.0",
),
```

`removed_from_collection` must be a collection name in `namespace.collection format`. The value `"1.13"` is a version number that was incorrectly placed here, likely meaning "deprecated since collection version 1.13"
.
ansible-core 2.19 introduced strict runtime validation of this field via `validate_collection_name()` in `ansible/module_utils/_internal/_validation.py`. When a task passes `protocol` as a parameter, ansible-core processes the deprecation, calls `deprecator_from_collection_name("1.13")`, and raises a `ValueError` because `"1.13"` is not a valid `namespace.collection` string. Older ansible-core versions silently ignored this malformed value.

Fix
===

Set `removed_from_collection` to the correct collection name:
```
protocol=dict(
    type="str",
    choices=["fc", "iscsi", "nvme", "mixed"],
    removed_from_collection="purestorage.flasharray",
    removed_in_version="2.0.0",
),
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_host.py

##### ADDITIONAL INFORMATION
Closes #980 