### PR TITLE
Add custom parameter support to purefa_workload & bugfixes

### DIFF
--- a/changelogs/fragments/1006_purefa_workload.yml
+++ b/changelogs/fragments/1006_purefa_workload.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - purefa_workload - Added custom parameters support
+
+bugfixes:
+  - purefa_dns - Fixed issue with purefa_dns not updating DNS config on remote arrays correctly
+  - purefa_host - Fixed issue with purefa_host not updating host config on remote arrays correctly

--- a/plugins/modules/purefa_dns.py
+++ b/plugins/modules/purefa_dns.py
@@ -143,6 +143,12 @@ def remove(duplicate):
     return final_list
 
 
+def _get_dns_field(config, field):
+    if isinstance(config, dict):
+        return config.get(field)
+    return getattr(config, field, None)
+
+
 def _get_source(module, array):
     res = get_with_context(
         array,
@@ -181,13 +187,19 @@ def delete_dns(module, array):
 def create_dns(module, array):
     """Set DNS settings"""
     changed = False
-    current_dns = list(array.get_dns().items)[0]
-    if current_dns["domain"] != module.params["domain"] or sorted(
+    current_dns = list(
+        get_with_context(array, "get_dns", CONTEXT_API_VERSION, module).items
+    )[0]
+    if _get_dns_field(current_dns, "domain") != module.params["domain"] or sorted(
         module.params["nameservers"]
-    ) != sorted(current_dns["nameservers"]):
+    ) != sorted(_get_dns_field(current_dns, "nameservers") or []):
         changed = True
         if not module.check_mode:
-            res = array.patch_dns(
+            res = get_with_context(
+                array,
+                "patch_dns",
+                CONTEXT_API_VERSION,
+                module,
                 names=["management"],
                 dns=DnsPatch(
                     domain=module.params["domain"],
@@ -337,13 +349,21 @@ def main():
     state = module.params["state"]
     array = get_array(module)
     api_version = array.get_rest_version()
+    if module.params["context"] and LooseVersion(CONTEXT_API_VERSION) > LooseVersion(
+        api_version
+    ):
+        module.fail_json(
+            msg=f"`context` requires REST API version {CONTEXT_API_VERSION} or higher for DNS operations"
+        )
     if module.params["nameservers"]:
         module.params["nameservers"] = remove(module.params["nameservers"])
         if module.params["service"] == "management":
             module.params["nameservers"] = module.params["nameservers"][0:3]
 
     if LooseVersion(MULTIPLE_DNS) <= LooseVersion(api_version):
-        configs = list(array.get_dns().items)
+        configs = list(
+            get_with_context(array, "get_dns", CONTEXT_API_VERSION, module).items
+        )
         exists = False
         for config in configs:
             if config.name == module.params["name"]:

--- a/plugins/modules/purefa_host.py
+++ b/plugins/modules/purefa_host.py
@@ -377,6 +377,7 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.version imp
 from ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers import (
     get_with_context,
     check_response,
+    get_cached_api_version,
 )
 
 VLAN_API_VERSION = "2.16"
@@ -443,15 +444,7 @@ def _set_host_initiators(module, array):
 
 def _update_host_initiators(module, array, answer=False):
     """Change host initiator if iscsi or nvme or add new FC WWNs"""
-    current_connectors = list(
-        get_with_context(
-            array,
-            "get_hosts",
-            CONTEXT_API_VERSION,
-            module,
-            names=[module.params["name"]],
-        ).items
-    )[0]
+    current_connectors = get_host(module, array)
     if module.params["nqn"]:
         if module.params["nqn"] != [""]:
             if sorted(current_connectors.nqns) != sorted(module.params["nqn"]):
@@ -683,15 +676,7 @@ def _set_chap_security(module, array):
 def _update_chap_security(module, array, answer=False):
     """Change CHAP usernames and passwords"""
     pattern = re.compile("[^ ]{12,255}")
-    chap = list(
-        get_with_context(
-            array,
-            "get_hosts",
-            CONTEXT_API_VERSION,
-            module,
-            names=[module.params["name"]],
-        ).items
-    )[0].chap
+    chap = get_host(module, array).chap
     if module.params["host_user"]:
         if module.params["host_password"] == "clear":
             if hasattr(chap, "host_user"):
@@ -775,15 +760,7 @@ def _update_chap_security(module, array, answer=False):
 
 def _update_host_personality(module, array, answer=False):
     """Change host personality"""
-    host = list(
-        get_with_context(
-            array,
-            "get_hosts",
-            CONTEXT_API_VERSION,
-            module,
-            names=[module.params["name"]],
-        ).items
-    )[0]
+    host = get_host(module, array)
     if not hasattr(host, "personality") and module.params["personality"] != "delete":
         answer = True
         if not module.check_mode:
@@ -826,15 +803,7 @@ def _update_host_personality(module, array, answer=False):
 
 def _update_preferred_array(module, array, answer=False):
     """Update existing preferred array list"""
-    preferred_array = list(
-        get_with_context(
-            array,
-            "get_hosts",
-            CONTEXT_API_VERSION,
-            module,
-            names=[module.params["name"]],
-        ).items
-    )[0].preferred_arrays
+    preferred_array = get_host(module, array).preferred_arrays
     if preferred_array == [] and module.params["preferred_array"] != ["delete"]:
         answer = True
         preferred_array_list = []
@@ -916,19 +885,7 @@ def _set_vlan(module, array):
 
 def _update_vlan(module, array):
     changed = False
-    host_vlan = getattr(
-        list(
-            get_with_context(
-                array,
-                "get_hosts",
-                CONTEXT_API_VERSION,
-                module,
-                names=[module.params["name"]],
-            ).items
-        )[0],
-        "vlan",
-        None,
-    )
+    host_vlan = getattr(get_host(module, array), "vlan", None)
     if module.params["vlan"] != host_vlan:
         changed = True
         if not module.check_mode:
@@ -960,38 +917,34 @@ def get_multi_hosts(module, array):
             hosts.append(
                 module.params["name"] + str(host_num).zfill(module.params["digits"])
             )
-    res = get_with_context(array, "get_hosts", CONTEXT_API_VERSION, module, names=hosts)
-    return bool(res.status_code == 200)
+    return len(_get_hosts(module, array, hosts)) == len(hosts)
+
+
+def _get_hosts(module, array, names):
+    res = get_with_context(
+        array,
+        "get_hosts",
+        CONTEXT_API_VERSION,
+        module,
+        names=names,
+        allow_errors=True,
+    )
+    return list(getattr(res, "items", []) or [])
+
+
+def _get_named_host(module, array, name):
+    hosts = _get_hosts(module, array, [name])
+    return hosts[0] if hosts else None
 
 
 def get_host(module, array):
     """Return host or None"""
-    host = None
-    res = get_with_context(
-        array,
-        "get_hosts",
-        CONTEXT_API_VERSION,
-        module,
-        names=[module.params["name"]],
-    )
-    if res.status_code == 200:
-        host = list(res.items)[0]
-    return host
+    return _get_named_host(module, array, module.params["name"])
 
 
 def rename_exists(module, array):
     """Determine if rename target already exists"""
-    exists = False
-    res = get_with_context(
-        array,
-        "get_hosts",
-        CONTEXT_API_VERSION,
-        module,
-        names=[module.params["rename"]],
-    )
-    if res.status_code == 200:
-        exists = True
-    return exists
+    return _get_named_host(module, array, module.params["rename"]) is not None
 
 
 def make_multi_hosts(module, array):
@@ -1079,11 +1032,6 @@ def update_host(module, array):
     renamed = False
     vol_changed = False
     vlan_changed = False
-    # Need api_version for VLAN_API_VERSION check
-    from ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers import (
-        get_cached_api_version,
-    )
-
     api_version = get_cached_api_version(array)
     if module.params["state"] == "present":
         if (
@@ -1169,16 +1117,10 @@ def delete_host(module, array):
     """Delete a host"""
     changed = True
     if not module.check_mode:
-        host_res = get_with_context(
-            array,
-            "get_hosts",
-            CONTEXT_API_VERSION,
-            module,
-            names=[module.params["name"]],
-        )
-        has_hg = hasattr(list(host_res.items)[0].host_group, "name")
+        host_res = get_host(module, array)
+        has_hg = hasattr(host_res.host_group, "name")
         if has_hg:
-            host_group_name = list(host_res.items)[0].host_group.name
+            host_group_name = host_res.host_group.name
             res = get_with_context(
                 array,
                 "delete_host_groups_hosts",
@@ -1239,15 +1181,7 @@ def move_host(module, array):
         module.fail_json(msg="host must be provided with current realm name")
     # if "::" in module.params["name"]:
     #    current_realm = module.params["name"].split("::")[0]
-    current_connections = list(
-        get_with_context(
-            array,
-            "get_hosts",
-            CONTEXT_API_VERSION,
-            module,
-            names=[module.params["name"]],
-        ).items
-    )[0].connection_count
+    current_connections = get_host(module, array).connection_count
     if current_connections > 0:
         module.fail_json(msg="Hosts cannot be moved with existing volume connections.")
     changed = True
@@ -1376,11 +1310,6 @@ def main():
             msg="py-pure-client sdk is required to support 'vlan' parameter"
         )
     array = get_array(module)
-    # Need api_version for VLAN_API_VERSION check
-    from ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers import (
-        get_cached_api_version,
-    )
-
     api_version = get_cached_api_version(array)
     pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$")
     if module.params["rename"]:

--- a/plugins/modules/purefa_workload.py
+++ b/plugins/modules/purefa_workload.py
@@ -74,6 +74,56 @@ options:
       one is available
     default: false
     type: bool
+  parameters:
+    description:
+    - Parameter values to apply when creating a workload from the preset.
+    - Parameters are only applied on the create path and are not applied
+      when recovering an existing destroyed workload.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+        - Name of the preset parameter to set.
+        type: str
+        required: true
+      value:
+        description:
+        - Value for the preset parameter.
+        - Exactly one of C(string), C(integer), C(boolean), or
+          C(resource_reference) must be provided.
+        type: dict
+        required: true
+        suboptions:
+          string:
+            description:
+            - String parameter value.
+            type: str
+          integer:
+            description:
+            - Integer parameter value.
+            type: int
+          boolean:
+            description:
+            - Boolean parameter value.
+            type: bool
+          resource_reference:
+            description:
+            - Reference to another resource.
+            type: dict
+            suboptions:
+              id:
+                description:
+                - ID of the referenced resource.
+                type: str
+              name:
+                description:
+                - Name of the referenced resource.
+                type: str
+              resource_type:
+                description:
+                - Optional resource type for the reference.
+                type: str
   volume_count:
     description:
     - Number of additional volumes to add to an existing workload
@@ -103,6 +153,19 @@ EXAMPLES = r"""
     preset: bar
     host: myhost
     recommendation: true
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create a workload using preset parameters
+  purestorage.flasharray.purefa_workload:
+    name: foo
+    preset: bar
+    context: arr1
+    parameters:
+      - name: replication_target
+        value:
+          resource_reference:
+            name: arr2
     fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
@@ -170,6 +233,9 @@ HAS_PURESTORAGE = True
 try:
     from pypureclient.flasharray import (
         WorkloadConfigurationReference,
+        WorkloadParameter,
+        WorkloadParameterValue,
+        WorkloadParameterValueResourceReference,
         WorkloadPatch,
         WorkloadPost,
         WorkloadPlacementRecommendation,
@@ -195,6 +261,161 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers
 VERSION = 1.5
 USER_AGENT_BASE = "Ansible"
 MIN_REQUIRED_API_VERSION = "2.40"
+SUPPORTED_PARAMETER_VALUE_TYPES = (
+    "string",
+    "integer",
+    "boolean",
+    "resource_reference",
+)
+
+
+def _parameter_fail(module, parameter_name, message):
+    module.fail_json(msg=f"Invalid workload parameter '{parameter_name}': {message}")
+
+
+def _coerce_parameter_list(parameter_items):
+    if parameter_items is None:
+        return []
+    try:
+        return list(parameter_items)
+    except TypeError:
+        return []
+
+
+def _supplied_option_keys(value_definition, allowed_keys):
+    return [
+        key
+        for key in allowed_keys
+        if key in value_definition and value_definition[key] is not None
+    ]
+
+
+def _build_resource_reference(module, parameter_name, resource_reference):
+    if not isinstance(resource_reference, dict):
+        _parameter_fail(
+            module,
+            parameter_name,
+            "resource_reference must be a dictionary",
+        )
+    unknown_keys = set(resource_reference) - {"id", "name", "resource_type"}
+    if unknown_keys:
+        _parameter_fail(
+            module,
+            parameter_name,
+            "resource_reference contains unsupported keys: {0}".format(
+                ", ".join(sorted(unknown_keys))
+            ),
+        )
+    identifier_keys = _supplied_option_keys(resource_reference, ("id", "name"))
+    if len(identifier_keys) != 1:
+        _parameter_fail(
+            module,
+            parameter_name,
+            "resource_reference must include exactly one of id or name",
+        )
+    return WorkloadParameterValueResourceReference(
+        **{
+            key: resource_reference[key]
+            for key in resource_reference
+            if resource_reference[key] is not None
+        }
+    )
+
+
+def _build_parameter_value(module, parameter_name, value_definition):
+    if not isinstance(value_definition, dict):
+        _parameter_fail(module, parameter_name, "value must be a dictionary")
+    unknown_keys = set(value_definition) - set(SUPPORTED_PARAMETER_VALUE_TYPES)
+    if unknown_keys:
+        _parameter_fail(
+            module,
+            parameter_name,
+            "value contains unsupported keys: {0}".format(
+                ", ".join(sorted(unknown_keys))
+            ),
+        )
+    supplied_value_types = _supplied_option_keys(
+        value_definition, SUPPORTED_PARAMETER_VALUE_TYPES
+    )
+    if len(supplied_value_types) != 1:
+        _parameter_fail(
+            module,
+            parameter_name,
+            "value must include exactly one of {0}".format(
+                ", ".join(SUPPORTED_PARAMETER_VALUE_TYPES)
+            ),
+        )
+
+    value_type = supplied_value_types[0]
+    normalized_value = value_definition[value_type]
+    if value_type == "string":
+        if not isinstance(normalized_value, str):
+            _parameter_fail(module, parameter_name, "string value must be a string")
+    elif value_type == "integer":
+        if isinstance(normalized_value, bool) or not isinstance(normalized_value, int):
+            _parameter_fail(module, parameter_name, "integer value must be an integer")
+    elif value_type == "boolean":
+        if not isinstance(normalized_value, bool):
+            _parameter_fail(
+                module, parameter_name, "boolean value must be true or false"
+            )
+    elif value_type == "resource_reference":
+        normalized_value = _build_resource_reference(
+            module, parameter_name, normalized_value
+        )
+
+    return value_type, WorkloadParameterValue(**{value_type: normalized_value})
+
+
+def _build_workload_parameters(module, preset_config):
+    raw_parameters = module.params.get("parameters") or []
+    if not raw_parameters:
+        return None
+
+    preset_parameters = {}
+    for preset_parameter in _coerce_parameter_list(
+        getattr(preset_config, "parameters", [])
+    ):
+        if getattr(preset_parameter, "name", None):
+            preset_parameters[preset_parameter.name] = preset_parameter
+
+    normalized_parameters = []
+    seen_parameters = set()
+    for raw_parameter in raw_parameters:
+        if not isinstance(raw_parameter, dict):
+            module.fail_json(msg="Each workload parameter must be a dictionary")
+        parameter_name = raw_parameter.get("name")
+        if not parameter_name:
+            module.fail_json(msg="Each workload parameter requires a name")
+        if parameter_name in seen_parameters:
+            _parameter_fail(module, parameter_name, "parameter names must be unique")
+        if parameter_name not in preset_parameters:
+            _parameter_fail(
+                module,
+                parameter_name,
+                "parameter is not defined by preset {0}".format(
+                    module.params["preset"]
+                ),
+            )
+        if "value" not in raw_parameter:
+            _parameter_fail(module, parameter_name, "parameter requires a value")
+
+        value_type, parameter_value = _build_parameter_value(
+            module, parameter_name, raw_parameter["value"]
+        )
+        preset_type = getattr(preset_parameters[parameter_name], "type", None)
+        if preset_type and preset_type != value_type:
+            _parameter_fail(
+                module,
+                parameter_name,
+                "expected type {0}, got {1}".format(preset_type, value_type),
+            )
+
+        normalized_parameters.append(
+            WorkloadParameter(name=parameter_name, value=parameter_value)
+        )
+        seen_parameters.add(parameter_name)
+    return normalized_parameters
 
 
 def _create_volume(module, array):
@@ -251,17 +472,11 @@ def _connect_volumes(module, array):
 def create_workload(module, array, fleet, preset_config):
     """Create fleet workload using existing preset"""
     changed = True
-    parameters = preset_config.parameters
-    repl_config = preset_config.periodic_replication_configurations
-    placement_config = preset_config.placement_configurations
-    qos_config = preset_config.qos_configurations
-    snap_config = preset_config.snapshot_configurations
-    vol_config = preset_config.volume_configurations
-    tags = preset_config.workload_tags
+    workload_parameters = _build_workload_parameters(module, preset_config)
     if module.params["recommendation"]:
         # Start the workload calculation for the preset being used
         res = array.post_workloads_placement_recommendations(
-            inputs=WorkloadPlacementRecommendation(),
+            inputs=WorkloadPlacementRecommendation(parameters=workload_parameters),
             preset_names=[module.params["preset"]],
             context_names=[module.params["context"]],
         )
@@ -287,7 +502,7 @@ def create_workload(module, array, fleet, preset_config):
         res = array.post_workloads(
             names=[module.params["name"]],
             preset_names=[module.params["preset"]],
-            workload=WorkloadPost(),
+            workload=WorkloadPost(parameters=workload_parameters),
             context_names=[module.params["context"]],
         )
         check_response(
@@ -430,6 +645,30 @@ def main():
             rename=dict(type="str"),
             eradicate=dict(type="bool", default=False),
             placement=dict(type="str"),
+            parameters=dict(
+                type="list",
+                elements="dict",
+                options=dict(
+                    name=dict(type="str", required=True),
+                    value=dict(
+                        type="dict",
+                        required=True,
+                        options=dict(
+                            string=dict(type="str"),
+                            integer=dict(type="int"),
+                            boolean=dict(type="bool"),
+                            resource_reference=dict(
+                                type="dict",
+                                options=dict(
+                                    id=dict(type="str"),
+                                    name=dict(type="str"),
+                                    resource_type=dict(type="str"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
             volume_count=dict(type="int"),
             volume_configuration=dict(type="str"),
             recommendation=dict(type="bool", default=False),

--- a/tests/unit/plugins/modules/test_purefa_dns.py
+++ b/tests/unit/plugins/modules/test_purefa_dns.py
@@ -98,7 +98,8 @@ class TestDeleteDns:
 class TestCreateDns:
     """Test cases for create_dns function"""
 
-    def test_create_dns_no_change(self):
+    @patch("plugins.modules.purefa_dns.get_with_context")
+    def test_create_dns_no_change(self, mock_get_with_context):
         """Test create_dns when config matches"""
         mock_module = Mock()
         mock_module.check_mode = False
@@ -112,7 +113,7 @@ class TestCreateDns:
             "domain": "example.com",
             "nameservers": ["ns1.example.com", "ns2.example.com"],
         }
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
 
         create_dns(mock_module, mock_array)
 
@@ -195,7 +196,8 @@ class TestCreateDnsExtended:
     """Extended test cases for create_dns function"""
 
     @patch("plugins.modules.purefa_dns.check_response")
-    def test_create_dns_success(self, mock_check_response):
+    @patch("plugins.modules.purefa_dns.get_with_context")
+    def test_create_dns_success(self, mock_get_with_context, mock_check_response):
         """Test create_dns successfully creates DNS config"""
         mock_module = Mock()
         mock_module.check_mode = False
@@ -209,15 +211,18 @@ class TestCreateDnsExtended:
             "domain": "olddomain.com",
             "nameservers": ["old.example.com"],
         }
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
-        mock_array.patch_dns.return_value = Mock(status_code=200)
+        mock_get_with_context.side_effect = [
+            Mock(items=[mock_dns]),
+            Mock(status_code=200),
+        ]
 
         create_dns(mock_module, mock_array)
 
-        mock_array.patch_dns.assert_called_once()
+        assert mock_get_with_context.call_count == 2
         mock_module.exit_json.assert_called_once_with(changed=True)
 
-    def test_create_dns_check_mode(self):
+    @patch("plugins.modules.purefa_dns.get_with_context")
+    def test_create_dns_check_mode(self, mock_get_with_context):
         """Test create_dns in check mode"""
         mock_module = Mock()
         mock_module.check_mode = True
@@ -231,11 +236,11 @@ class TestCreateDnsExtended:
             "domain": "olddomain.com",
             "nameservers": ["old.example.com"],
         }
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
 
         create_dns(mock_module, mock_array)
 
-        mock_array.patch_dns.assert_not_called()
+        assert mock_get_with_context.call_count == 1
         mock_module.exit_json.assert_called_once_with(changed=True)
 
 
@@ -512,10 +517,12 @@ class TestMain:
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")
     @patch("plugins.modules.purefa_dns.LooseVersion")
+    @patch("plugins.modules.purefa_dns.get_with_context")
     @patch("plugins.modules.purefa_dns.update_multi_dns")
     def test_main_multi_dns_update(
         self,
         mock_update_multi_dns,
+        mock_get_with_context,
         mock_loose_version,
         mock_get_array,
         mock_ansible_module,
@@ -538,7 +545,7 @@ class TestMain:
         mock_array.get_rest_version.return_value = "2.38"
         mock_dns = Mock()
         mock_dns.name = "management"
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
         mock_get_array.return_value = mock_array
 
         import plugins.modules.purefa_dns as dns_module
@@ -550,10 +557,12 @@ class TestMain:
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")
     @patch("plugins.modules.purefa_dns.LooseVersion")
+    @patch("plugins.modules.purefa_dns.get_with_context")
     @patch("plugins.modules.purefa_dns.create_multi_dns")
     def test_main_multi_dns_create(
         self,
         mock_create_multi_dns,
+        mock_get_with_context,
         mock_loose_version,
         mock_get_array,
         mock_ansible_module,
@@ -575,7 +584,7 @@ class TestMain:
         mock_array.get_rest_version.return_value = "2.38"
         mock_dns = Mock()
         mock_dns.name = "management"
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
         mock_get_array.return_value = mock_array
 
         import plugins.modules.purefa_dns as dns_module
@@ -587,10 +596,12 @@ class TestMain:
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")
     @patch("plugins.modules.purefa_dns.LooseVersion")
+    @patch("plugins.modules.purefa_dns.get_with_context")
     @patch("plugins.modules.purefa_dns.delete_multi_dns")
     def test_main_multi_dns_delete(
         self,
         mock_delete_multi_dns,
+        mock_get_with_context,
         mock_loose_version,
         mock_get_array,
         mock_ansible_module,
@@ -612,7 +623,7 @@ class TestMain:
         mock_array.get_rest_version.return_value = "2.38"
         mock_dns = Mock()
         mock_dns.name = "file-dns"
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
         mock_get_array.return_value = mock_array
 
         import plugins.modules.purefa_dns as dns_module
@@ -624,8 +635,13 @@ class TestMain:
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")
     @patch("plugins.modules.purefa_dns.LooseVersion")
+    @patch("plugins.modules.purefa_dns.get_with_context")
     def test_main_multi_dns_absent_not_exists(
-        self, mock_loose_version, mock_get_array, mock_ansible_module
+        self,
+        mock_get_with_context,
+        mock_loose_version,
+        mock_get_array,
+        mock_ansible_module,
     ):
         """Test main exits unchanged when absent and config doesn't exist"""
         mock_loose_version.side_effect = lambda x: x
@@ -644,7 +660,7 @@ class TestMain:
         mock_array.get_rest_version.return_value = "2.38"
         mock_dns = Mock()
         mock_dns.name = "management"
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
         mock_get_array.return_value = mock_array
 
         import plugins.modules.purefa_dns as dns_module
@@ -656,8 +672,13 @@ class TestMain:
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")
     @patch("plugins.modules.purefa_dns.LooseVersion")
+    @patch("plugins.modules.purefa_dns.get_with_context")
     def test_main_multi_dns_max_configs(
-        self, mock_loose_version, mock_get_array, mock_ansible_module
+        self,
+        mock_get_with_context,
+        mock_loose_version,
+        mock_get_array,
+        mock_ansible_module,
     ):
         """Test main fails when trying to add third DNS config"""
         import pytest
@@ -681,7 +702,7 @@ class TestMain:
         mock_dns1.name = "management"
         mock_dns2 = Mock()
         mock_dns2.name = "file-dns"
-        mock_array.get_dns.return_value = Mock(items=[mock_dns1, mock_dns2])
+        mock_get_with_context.return_value = Mock(items=[mock_dns1, mock_dns2])
         mock_get_array.return_value = mock_array
 
         import plugins.modules.purefa_dns as dns_module
@@ -694,9 +715,15 @@ class TestMain:
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")
     @patch("plugins.modules.purefa_dns.LooseVersion")
+    @patch("plugins.modules.purefa_dns.get_with_context")
     @patch("plugins.modules.purefa_dns._get_source")
     def test_main_multi_dns_invalid_source(
-        self, mock_get_source, mock_loose_version, mock_get_array, mock_ansible_module
+        self,
+        mock_get_source,
+        mock_get_with_context,
+        mock_loose_version,
+        mock_get_array,
+        mock_ansible_module,
     ):
         """Test main fails when source VIF doesn't exist"""
         import pytest
@@ -718,7 +745,7 @@ class TestMain:
         mock_array.get_rest_version.return_value = "2.38"
         mock_dns = Mock()
         mock_dns.name = "file-dns"
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
         mock_get_array.return_value = mock_array
         mock_get_source.return_value = False
 
@@ -732,10 +759,12 @@ class TestMain:
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")
     @patch("plugins.modules.purefa_dns.LooseVersion")
+    @patch("plugins.modules.purefa_dns.get_with_context")
     @patch("plugins.modules.purefa_dns.update_multi_dns")
     def test_main_multi_dns_override_name_to_management(
         self,
         mock_update_multi_dns,
+        mock_get_with_context,
         mock_loose_version,
         mock_get_array,
         mock_ansible_module,
@@ -757,7 +786,7 @@ class TestMain:
         mock_array.get_rest_version.return_value = "2.38"
         mock_dns = Mock()
         mock_dns.name = "management"
-        mock_array.get_dns.return_value = Mock(items=[mock_dns])
+        mock_get_with_context.return_value = Mock(items=[mock_dns])
         mock_get_array.return_value = mock_array
 
         import plugins.modules.purefa_dns as dns_module
@@ -765,6 +794,39 @@ class TestMain:
         dns_module.main()
 
         mock_module.warn.assert_called_once()
+
+    @patch("plugins.modules.purefa_dns.AnsibleModule")
+    @patch("plugins.modules.purefa_dns.get_array")
+    @patch("plugins.modules.purefa_dns.LooseVersion")
+    def test_main_fails_when_context_not_supported(
+        self, mock_loose_version, mock_get_array, mock_ansible_module
+    ):
+        """Test main fails when DNS context is requested on unsupported API."""
+        import pytest
+
+        mock_loose_version.side_effect = lambda x: x
+        mock_module = Mock()
+        mock_module.params = {
+            "state": "present",
+            "name": "management",
+            "service": "management",
+            "domain": "example.com",
+            "nameservers": ["ns1.example.com"],
+            "source": None,
+            "context": "array-b",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible_module.return_value = mock_module
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.38"
+        mock_get_array.return_value = mock_array
+
+        import plugins.modules.purefa_dns as dns_module
+
+        with pytest.raises(SystemExit):
+            dns_module.main()
+
+        mock_module.fail_json.assert_called_once()
 
     @patch("plugins.modules.purefa_dns.AnsibleModule")
     @patch("plugins.modules.purefa_dns.get_array")

--- a/tests/unit/plugins/modules/test_purefa_host.py
+++ b/tests/unit/plugins/modules/test_purefa_host.py
@@ -96,6 +96,7 @@ class TestGetHost:
         result = get_host(mock_module, mock_array)
 
         assert result == mock_host
+        assert mock_get_with_context.call_args.kwargs["allow_errors"] is True
 
     @patch("plugins.modules.purefa_host.get_with_context")
     def test_get_host_not_exists(self, mock_get_with_context):
@@ -104,11 +105,12 @@ class TestGetHost:
         mock_module.params = {"name": "nonexistent-host"}
         mock_array = Mock()
 
-        mock_get_with_context.return_value = Mock(status_code=404)
+        mock_get_with_context.return_value = Mock(status_code=200, items=[])
 
         result = get_host(mock_module, mock_array)
 
         assert result is None
+        assert mock_get_with_context.call_args.kwargs["allow_errors"] is True
 
 
 class TestGetMultiHosts:
@@ -127,11 +129,14 @@ class TestGetMultiHosts:
         }
         mock_array = Mock()
 
-        mock_get_with_context.return_value = Mock(status_code=200)
+        mock_get_with_context.return_value = Mock(
+            status_code=200, items=[Mock(), Mock(), Mock()]
+        )
 
         result = get_multi_hosts(mock_module, mock_array)
 
         assert result is True
+        assert mock_get_with_context.call_args.kwargs["allow_errors"] is True
 
     @patch("plugins.modules.purefa_host.get_with_context")
     def test_get_multi_hosts_not_exist(self, mock_get_with_context):
@@ -146,11 +151,14 @@ class TestGetMultiHosts:
         }
         mock_array = Mock()
 
-        mock_get_with_context.return_value = Mock(status_code=404)
+        mock_get_with_context.return_value = Mock(
+            status_code=207, items=[Mock(), Mock()]
+        )
 
         result = get_multi_hosts(mock_module, mock_array)
 
         assert result is False
+        assert mock_get_with_context.call_args.kwargs["allow_errors"] is True
 
     @patch("plugins.modules.purefa_host.get_with_context")
     def test_get_multi_hosts_with_suffix(self, mock_get_with_context):
@@ -165,13 +173,16 @@ class TestGetMultiHosts:
         }
         mock_array = Mock()
 
-        mock_get_with_context.return_value = Mock(status_code=200)
+        mock_get_with_context.return_value = Mock(
+            status_code=200, items=[Mock(), Mock()]
+        )
 
         result = get_multi_hosts(mock_module, mock_array)
 
         assert result is True
         # Verify the hosts list includes suffix
         call_args = mock_get_with_context.call_args
+        assert call_args.kwargs["allow_errors"] is True
         assert "host001_server" in call_args.kwargs["names"]
         assert "host002_server" in call_args.kwargs["names"]
 
@@ -186,11 +197,12 @@ class TestRenameExists:
         mock_module.params = {"rename": "new-host-name"}
         mock_array = Mock()
 
-        mock_get_with_context.return_value = Mock(status_code=200)
+        mock_get_with_context.return_value = Mock(status_code=200, items=[Mock()])
 
         result = rename_exists(mock_module, mock_array)
 
         assert result is True
+        assert mock_get_with_context.call_args.kwargs["allow_errors"] is True
 
     @patch("plugins.modules.purefa_host.get_with_context")
     def test_rename_exists_false(self, mock_get_with_context):
@@ -199,11 +211,12 @@ class TestRenameExists:
         mock_module.params = {"rename": "new-host-name"}
         mock_array = Mock()
 
-        mock_get_with_context.return_value = Mock(status_code=404)
+        mock_get_with_context.return_value = Mock(status_code=200, items=[])
 
         result = rename_exists(mock_module, mock_array)
 
         assert result is False
+        assert mock_get_with_context.call_args.kwargs["allow_errors"] is True
 
 
 class TestMakeHost:
@@ -402,9 +415,7 @@ class TestDeleteHost:
 class TestUpdateHost:
     """Test cases for update_host function"""
 
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.LooseVersion")
     def test_update_host_no_changes(self, mock_loose_version, mock_get_api_version):
         """Test update_host with no changes needed"""
@@ -1426,6 +1437,7 @@ class TestMoveHostExtended:
         with pytest.raises(SystemExit):
             move_host(mock_module, mock_array)
 
+        assert mock_get_with_context.call_args.kwargs["allow_errors"] is True
         mock_module.fail_json.assert_called_once_with(
             msg="Hosts cannot be moved with existing volume connections."
         )
@@ -1796,6 +1808,7 @@ class TestUpdateHostInitiatorsExtended:
         result = _update_host_initiators(mock_module, mock_array)
 
         assert result is True
+        assert mock_get.call_args_list[0].kwargs["allow_errors"] is True
 
     @patch("plugins.modules.purefa_host.check_response")
     @patch("plugins.modules.purefa_host.get_with_context")
@@ -2217,9 +2230,7 @@ class TestMakeHostWithVolume:
 class TestUpdateHostRename:
     """Test cases for update_host with rename"""
 
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.rename_exists")
     @patch("plugins.modules.purefa_host.check_response")
     @patch("plugins.modules.purefa_host.get_with_context")
@@ -2263,9 +2274,7 @@ class TestUpdateHostRename:
 
         mock_module.exit_json.assert_called_once_with(changed=True)
 
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.rename_exists")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
@@ -2303,9 +2312,7 @@ class TestUpdateHostRename:
 class TestUpdateHostDisconnectVolume:
     """Test cases for update_host disconnecting a volume"""
 
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host._disconnect_volume")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
@@ -2374,6 +2381,7 @@ class TestDeleteHostWithHostGroup:
 
         mock_module.exit_json.assert_called_once_with(changed=True)
         assert mock_get.call_count == 4
+        assert mock_get.call_args_list[0].kwargs["allow_errors"] is True
 
 
 class TestSetChapSecurityValidation:
@@ -2471,6 +2479,7 @@ class TestUpdateVlanPaths:
 
         assert result is True
         assert mock_get.call_count == 2
+        assert mock_get.call_args_list[0].kwargs["allow_errors"] is True
 
     @patch("plugins.modules.purefa_host.get_with_context")
     def test_update_vlan_no_change(self, mock_get):
@@ -2620,9 +2629,7 @@ class TestUpdateHostWithAllOptions:
     """Test cases for update_host with all update paths"""
 
     @patch("plugins.modules.purefa_host._update_vlan")
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
     def test_update_host_with_vlan(
@@ -2657,9 +2664,7 @@ class TestUpdateHostWithAllOptions:
         mock_module.exit_json.assert_called_once_with(changed=True)
 
     @patch("plugins.modules.purefa_host._update_host_initiators")
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
     def test_update_host_with_initiators(
@@ -2694,9 +2699,7 @@ class TestUpdateHostWithAllOptions:
         mock_module.exit_json.assert_called_once_with(changed=True)
 
     @patch("plugins.modules.purefa_host._connect_new_volume")
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
     def test_update_host_connect_new_volume(
@@ -2732,9 +2735,7 @@ class TestUpdateHostWithAllOptions:
         mock_module.exit_json.assert_called_once_with(changed=True)
 
     @patch("plugins.modules.purefa_host._update_host_personality")
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
     def test_update_host_with_personality(
@@ -2769,9 +2770,7 @@ class TestUpdateHostWithAllOptions:
         mock_module.exit_json.assert_called_once_with(changed=True)
 
     @patch("plugins.modules.purefa_host._update_preferred_array")
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
     def test_update_host_with_preferred_array(
@@ -2806,9 +2805,7 @@ class TestUpdateHostWithAllOptions:
         mock_module.exit_json.assert_called_once_with(changed=True)
 
     @patch("plugins.modules.purefa_host._update_chap_security")
-    @patch(
-        "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers.get_cached_api_version"
-    )
+    @patch("plugins.modules.purefa_host.get_cached_api_version")
     @patch("plugins.modules.purefa_host.get_with_context")
     @patch("plugins.modules.purefa_host.LooseVersion", side_effect=lambda x: x)
     def test_update_host_with_chap(

--- a/tests/unit/plugins/modules/test_purefa_workload.py
+++ b/tests/unit/plugins/modules/test_purefa_workload.py
@@ -43,6 +43,7 @@ sys.modules[
 ] = MagicMock()
 
 from plugins.modules.purefa_workload import (
+    _build_workload_parameters,
     delete_workload,
     eradicate_workload,
     recover_workload,
@@ -51,6 +52,13 @@ from plugins.modules.purefa_workload import (
     expand_workload,
     connect_or_disconnect_volumes,
 )
+
+
+def _mock_preset_parameter(name, parameter_type):
+    preset_parameter = Mock()
+    preset_parameter.name = name
+    preset_parameter.type = parameter_type
+    return preset_parameter
 
 
 class TestDeleteWorkload:
@@ -138,7 +146,7 @@ class TestCreateWorkload:
         mock_array = Mock()
         mock_fleet = Mock()
         mock_preset_config = Mock()
-        mock_preset_config.parameters = Mock()
+        mock_preset_config.parameters = []
         mock_preset_config.periodic_replication_configurations = []
         mock_preset_config.placement_configurations = []
         mock_preset_config.qos_configurations = []
@@ -149,6 +157,199 @@ class TestCreateWorkload:
         create_workload(mock_module, mock_array, mock_fleet, mock_preset_config)
 
         mock_module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestBuildWorkloadParameters:
+    """Test cases for workload parameter normalization"""
+
+    @patch("plugins.modules.purefa_workload.WorkloadParameter")
+    @patch("plugins.modules.purefa_workload.WorkloadParameterValue")
+    @patch("plugins.modules.purefa_workload.WorkloadParameterValueResourceReference")
+    def test_build_workload_parameters_resource_reference(
+        self,
+        mock_resource_reference,
+        mock_parameter_value,
+        mock_parameter,
+    ):
+        """Test resource reference workload parameters are normalized"""
+        mock_module = Mock()
+        mock_module.params = {
+            "preset": "fleet:Oracle",
+            "parameters": [
+                {
+                    "name": "replication_target",
+                    "value": {"resource_reference": {"name": "slcfax2"}},
+                }
+            ],
+        }
+        mock_preset_config = Mock()
+        mock_preset_config.parameters = [
+            _mock_preset_parameter("replication_target", "resource_reference")
+        ]
+
+        result = _build_workload_parameters(mock_module, mock_preset_config)
+
+        assert result == [mock_parameter.return_value]
+        mock_resource_reference.assert_called_once_with(name="slcfax2")
+        mock_parameter_value.assert_called_once_with(
+            resource_reference=mock_resource_reference.return_value
+        )
+        mock_parameter.assert_called_once_with(
+            name="replication_target", value=mock_parameter_value.return_value
+        )
+
+    @patch("plugins.modules.purefa_workload.WorkloadParameter")
+    @patch("plugins.modules.purefa_workload.WorkloadParameterValue")
+    def test_build_workload_parameters_boolean_false(
+        self, mock_parameter_value, mock_parameter
+    ):
+        """Test boolean false is treated as a supplied value"""
+        mock_module = Mock()
+        mock_module.params = {
+            "preset": "fleet:Oracle",
+            "parameters": [{"name": "enable_replication", "value": {"boolean": False}}],
+        }
+        mock_preset_config = Mock()
+        mock_preset_config.parameters = [
+            _mock_preset_parameter("enable_replication", "boolean")
+        ]
+
+        result = _build_workload_parameters(mock_module, mock_preset_config)
+
+        assert result == [mock_parameter.return_value]
+        mock_parameter_value.assert_called_once_with(boolean=False)
+        mock_parameter.assert_called_once_with(
+            name="enable_replication", value=mock_parameter_value.return_value
+        )
+
+    @patch("plugins.modules.purefa_workload.WorkloadParameter")
+    @patch("plugins.modules.purefa_workload.WorkloadParameterValue")
+    def test_build_workload_parameters_boolean_false_ignores_none_value_types(
+        self, mock_parameter_value, mock_parameter
+    ):
+        """Test Ansible-normalized None value types are ignored for booleans"""
+        mock_module = Mock()
+        mock_module.params = {
+            "preset": "fleet:Oracle",
+            "parameters": [
+                {
+                    "name": "enable_replication",
+                    "value": {
+                        "string": None,
+                        "integer": None,
+                        "boolean": False,
+                        "resource_reference": None,
+                    },
+                }
+            ],
+        }
+        mock_preset_config = Mock()
+        mock_preset_config.parameters = [
+            _mock_preset_parameter("enable_replication", "boolean")
+        ]
+
+        result = _build_workload_parameters(mock_module, mock_preset_config)
+
+        assert result == [mock_parameter.return_value]
+        mock_parameter_value.assert_called_once_with(boolean=False)
+        mock_parameter.assert_called_once_with(
+            name="enable_replication", value=mock_parameter_value.return_value
+        )
+
+    def test_build_workload_parameters_rejects_multiple_value_types(self):
+        """Test multiple parameter value types are rejected"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.params = {
+            "preset": "fleet:Oracle",
+            "parameters": [
+                {
+                    "name": "replication_target",
+                    "value": {"string": "slcfax2", "integer": 1},
+                }
+            ],
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_preset_config = Mock()
+        mock_preset_config.parameters = [
+            _mock_preset_parameter("replication_target", "string")
+        ]
+
+        with pytest.raises(SystemExit):
+            _build_workload_parameters(mock_module, mock_preset_config)
+
+        mock_module.fail_json.assert_called_once()
+
+    @patch("plugins.modules.purefa_workload.WorkloadParameter")
+    @patch("plugins.modules.purefa_workload.WorkloadParameterValue")
+    @patch("plugins.modules.purefa_workload.WorkloadParameterValueResourceReference")
+    def test_build_workload_parameters_resource_reference_ignores_none_fields(
+        self,
+        mock_resource_reference,
+        mock_parameter_value,
+        mock_parameter,
+    ):
+        """Test Ansible-normalized None fields are ignored for resource references"""
+        mock_module = Mock()
+        mock_module.params = {
+            "preset": "fleet:Oracle",
+            "parameters": [
+                {
+                    "name": "replication_target",
+                    "value": {
+                        "string": None,
+                        "integer": None,
+                        "boolean": None,
+                        "resource_reference": {
+                            "id": None,
+                            "name": "slcfax2",
+                            "resource_type": None,
+                        },
+                    },
+                }
+            ],
+        }
+        mock_preset_config = Mock()
+        mock_preset_config.parameters = [
+            _mock_preset_parameter("replication_target", "resource_reference")
+        ]
+
+        result = _build_workload_parameters(mock_module, mock_preset_config)
+
+        assert result == [mock_parameter.return_value]
+        mock_resource_reference.assert_called_once_with(name="slcfax2")
+        mock_parameter_value.assert_called_once_with(
+            resource_reference=mock_resource_reference.return_value
+        )
+        mock_parameter.assert_called_once_with(
+            name="replication_target", value=mock_parameter_value.return_value
+        )
+
+    def test_build_workload_parameters_rejects_invalid_resource_reference(self):
+        """Test invalid resource references are rejected"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.params = {
+            "preset": "fleet:Oracle",
+            "parameters": [
+                {
+                    "name": "replication_target",
+                    "value": {"resource_reference": {"id": "123", "name": "slcfax2"}},
+                }
+            ],
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_preset_config = Mock()
+        mock_preset_config.parameters = [
+            _mock_preset_parameter("replication_target", "resource_reference")
+        ]
+
+        with pytest.raises(SystemExit):
+            _build_workload_parameters(mock_module, mock_preset_config)
+
+        mock_module.fail_json.assert_called_once()
 
 
 class TestConnectOrDisconnectVolumes:
@@ -333,7 +534,7 @@ class TestCreateWorkloadSuccess:
         mock_array.post_workloads.return_value = Mock(status_code=200)
         mock_fleet = Mock()
         mock_preset_config = Mock()
-        mock_preset_config.parameters = Mock()
+        mock_preset_config.parameters = []
         mock_preset_config.periodic_replication_configurations = Mock()
         mock_preset_config.placement_configurations = Mock()
         mock_preset_config.qos_configurations = Mock()
@@ -344,6 +545,65 @@ class TestCreateWorkloadSuccess:
         create_workload(mock_module, mock_array, mock_fleet, mock_preset_config)
 
         mock_array.post_workloads.assert_called_once()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_workload._build_workload_parameters")
+    @patch("plugins.modules.purefa_workload.WorkloadPlacementRecommendation")
+    @patch("plugins.modules.purefa_workload.WorkloadPost")
+    @patch("plugins.modules.purefa_workload.check_response")
+    def test_create_workload_passes_parameters_to_recommendation_and_create(
+        self,
+        mock_check_response,
+        mock_workload_post,
+        mock_recommendation,
+        mock_build_workload_parameters,
+    ):
+        """Test create_workload passes parameters into recommendation and create APIs"""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {
+            "name": "test-workload",
+            "preset": "test-preset",
+            "context": "pod1",
+            "recommendation": True,
+            "host": "",
+        }
+        mock_array = Mock()
+        mock_array.post_workloads.return_value = Mock(status_code=200)
+        mock_calc = Mock()
+        mock_calc.name = "calc-1"
+        mock_array.post_workloads_placement_recommendations.return_value = Mock(
+            status_code=200, items=[mock_calc]
+        )
+        recommendation_result = Mock(status="completed")
+        placement_target = Mock()
+        placement_target.name = "arrayB"
+        recommendation_result.results = [Mock()]
+        recommendation_result.results[0].placements = [Mock()]
+        recommendation_result.results[0].placements[0].targets = [placement_target]
+        mock_array.get_workloads_placement_recommendations.return_value = Mock(
+            items=[recommendation_result]
+        )
+        mock_build_workload_parameters.return_value = [Mock(name="param-1")]
+        mock_preset_config = Mock()
+
+        create_workload(mock_module, mock_array, Mock(), mock_preset_config)
+
+        mock_build_workload_parameters.assert_called_once_with(
+            mock_module, mock_preset_config
+        )
+        mock_recommendation.assert_called_once_with(
+            parameters=mock_build_workload_parameters.return_value
+        )
+        mock_workload_post.assert_called_once_with(
+            parameters=mock_build_workload_parameters.return_value
+        )
+        mock_array.post_workloads.assert_called_once_with(
+            names=["test-workload"],
+            preset_names=["test-preset"],
+            workload=mock_workload_post.return_value,
+            context_names=["arrayB"],
+        )
         mock_module.exit_json.assert_called_once_with(changed=True)
 
     def test_create_workload_check_mode(self):
@@ -360,7 +620,7 @@ class TestCreateWorkloadSuccess:
         mock_array = Mock()
         mock_fleet = Mock()
         mock_preset_config = Mock()
-        mock_preset_config.parameters = Mock()
+        mock_preset_config.parameters = []
         mock_preset_config.periodic_replication_configurations = Mock()
         mock_preset_config.placement_configurations = Mock()
         mock_preset_config.qos_configurations = Mock()


### PR DESCRIPTION
##### SUMMARY
When provisioning a workload now, you can pass in additional custom parameters. For e.g., if the Preset defines custom paramters like billingID, remote-target, etc, this change now supports providing these parameters when provisioning from the preset.

Also, fixed a couple of issues:
1. Fixed issue with purefa_dns not updating DNS config on remote arrays correctly
2. Fixed issue with purefa_host not updating host config on remote arrays correctly

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_workload, purefa_dns, purefa_host

##### ADDITIONAL INFORMATION
1. Fixed issue with purefa_dns not updating DNS config on remote arrays correctly
purefa_dns was not using context when trying to list DNS config from remote arrays.
As a result, when trying to modify the DNS setting on a remote array, the playbook will end up looking up the DNS setting on the array that specified in fa_url, instead of the array that was specified in context.

2.  Fixed issue with purefa_host not updating host config on remote arrays correctly
purefa_host was using both context and a specific name with get_host when trying to lookup an existing host. 
When calling GET APIs with both name and context, allow_errors has to be explicitiy set to true. The default is false. And thus, get_host was returning 400 because it was not setting allow_errors=true. This change fixes that
