### PR TITLE
purefa - add API-client token authentication alongside api_token

### DIFF
--- a/changelogs/fragments/1007_apiclient_token_auth.yaml
+++ b/changelogs/fragments/1007_apiclient_token_auth.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa - Add API-client token authentication as an alternative to ``api_token``, via a pre-signed ``id_token`` or a ``private_key_file`` (with ``client_id``, ``key_id``, ``issuer``, ``username``).

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -30,6 +30,50 @@ options:
     description:
       - FlashArray API token for admin privileged user.
     type: str
+  id_token:
+    description:
+      - A pre-signed JWT to authenticate with, as an alternative to I(api_token).
+      - The token is exchanged by the array for a short-lived access token.
+      - Requires a matching API Client to be registered on the array
+        (see M(purestorage.flasharray.purefa_apiclient)).
+    type: str
+    version_added: '1.43.0'
+  private_key_file:
+    description:
+      - Path to the PEM RSA private key used to sign an identity token,
+        as an alternative to I(api_token).
+      - Requires I(client_id), I(key_id), I(issuer) and I(username).
+    type: str
+    version_added: '1.43.0'
+  private_key_password:
+    description:
+      - Password protecting I(private_key_file), if encrypted.
+    type: str
+    version_added: '1.43.0'
+  username:
+    description:
+      - Username the issued token should be granted to.
+      - Must be a valid user on the array. Used with I(private_key_file).
+    type: str
+    version_added: '1.43.0'
+  client_id:
+    description:
+      - ID of the API Client that issues the identity token.
+      - Used with I(private_key_file).
+    type: str
+    version_added: '1.43.0'
+  key_id:
+    description:
+      - Key ID of the API Client that issues the identity token.
+      - Used with I(private_key_file).
+    type: str
+    version_added: '1.43.0'
+  issuer:
+    description:
+      - The API Client's trusted identity issuer registered on the array.
+      - Used with I(private_key_file).
+    type: str
+    version_added: '1.43.0'
   disable_warnings:
     description:
      - Disable insecure certificate warnings in debug logs
@@ -41,6 +85,10 @@ notes:
   - Additional Python libraries may be required for specific modules.
   - You must set C(PUREFA_URL) and C(PUREFA_API) environment variables
     if I(fa_url) and I(api_token) arguments are not passed to the module directly.
+  - Token-based authentication (I(id_token), or I(private_key_file) with
+    I(client_id), I(key_id), I(issuer) and I(username)) may be used as an
+    alternative to I(api_token), and requires a matching API Client registered
+    on the array via M(purestorage.flasharray.purefa_apiclient).
 requirements:
   - python >= 3.3
   - purestorage >= 1.19

--- a/plugins/module_utils/purefa.py
+++ b/plugins/module_utils/purefa.py
@@ -75,34 +75,62 @@ def get_array(module):
             "version": VERSION,
             "platform": platform.platform(),
         }
-    array_name = module.params["fa_url"]
-    api = module.params["api_token"]
-    if HAS_PYPURECLIENT:
-        if array_name and api:
-            system = flasharray.Client(
-                target=array_name,
-                api_token=api,
-                user_agent=user_agent,
-            )
-        elif environ.get("PUREFA_URL") and environ.get("PUREFA_API"):
-            system = flasharray.Client(
-                target=(environ.get("PUREFA_URL")),
-                api_token=(environ.get("PUREFA_API")),
-                user_agent=user_agent,
-            )
-        else:
-            module.fail_json(
-                msg="You must set PUREFA_URL and PUREFA_API environment variables "
-                "or the fa_url and api_token module arguments"
-            )
-        try:
-            system.get_hardware()
-        except Exception:
-            module.fail_json(
-                msg="Pure Storage FlashArray authentication failed. Check your credentials"
-            )
-    else:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client and/or requests are not installed.")
+
+    # Module parameters take precedence over the matching PUREFA_* env vars.
+    # Three mutually-exclusive authentication modes are supported:
+    #   1. api_token - static API token (default, backwards compatible).
+    #   2. id_token - a pre-signed JWT, exchanged by the array for an access
+    #      token.
+    #   3. private_key_file with client_id, key_id, issuer and username - the
+    #      SDK signs the JWT locally before exchange.
+    # Modes 2 and 3 require a matching API Client registered on the array
+    # (see the purefa_apiclient module).
+    target = module.params["fa_url"] or environ.get("PUREFA_URL")
+    api = module.params["api_token"] or environ.get("PUREFA_API")
+    id_token = module.params.get("id_token") or environ.get("PUREFA_ID_TOKEN")
+    private_key_file = module.params.get("private_key_file") or environ.get(
+        "PUREFA_PRIVATE_KEY_FILE"
+    )
+    private_key_password = module.params.get("private_key_password") or environ.get(
+        "PUREFA_PRIVATE_KEY_PASSWORD"
+    )
+    username = module.params.get("username") or environ.get("PUREFA_USERNAME")
+    client_id = module.params.get("client_id") or environ.get("PUREFA_CLIENT_ID")
+    key_id = module.params.get("key_id") or environ.get("PUREFA_KEY_ID")
+    issuer = module.params.get("issuer") or environ.get("PUREFA_ISSUER")
+
+    common = {"target": target, "user_agent": user_agent}
+
+    if target and api:
+        system = flasharray.Client(api_token=api, **common)
+    elif target and id_token:
+        system = flasharray.Client(id_token=id_token, **common)
+    elif target and private_key_file and client_id and key_id and issuer and username:
+        system = flasharray.Client(
+            private_key_file=private_key_file,
+            private_key_password=private_key_password,
+            client_id=client_id,
+            key_id=key_id,
+            issuer=issuer,
+            username=username,
+            **common,
+        )
+    else:
+        module.fail_json(
+            msg="You must set PUREFA_URL and PUREFA_API environment variables "
+            "or the fa_url and api_token module arguments. Alternatively, use "
+            "token-based authentication via id_token, or private_key_file with "
+            "client_id, key_id, issuer and username (or the matching PUREFA_* "
+            "environment variables)."
+        )
+    try:
+        system.get_hardware()
+    except Exception:
+        module.fail_json(
+            msg="Pure Storage FlashArray authentication failed. Check your credentials"
+        )
     return system
 
 
@@ -112,5 +140,14 @@ def purefa_argument_spec():
     return dict(
         fa_url=dict(),
         api_token=dict(no_log=True),
+        # OAuth2 / API-client token authentication (alternatives to api_token).
+        # See the purefa_apiclient module for registering the trusted key.
+        id_token=dict(no_log=True),
+        private_key_file=dict(no_log=False),
+        private_key_password=dict(no_log=True),
+        username=dict(),
+        client_id=dict(),
+        key_id=dict(no_log=False),
+        issuer=dict(),
         disable_warnings=dict(type="bool", default=False),
     )

--- a/tests/unit/plugins/module_utils/test_purefa.py
+++ b/tests/unit/plugins/module_utils/test_purefa.py
@@ -1,0 +1,281 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefa module utilities."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock external dependencies before importing purefa
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flasharray"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+
+from plugins.module_utils.purefa import get_array, purefa_argument_spec
+
+
+class TestPurefaArgumentSpec:
+    """Tests for purefa_argument_spec function."""
+
+    def test_returns_dict(self):
+        """Test that function returns a dictionary."""
+        assert isinstance(purefa_argument_spec(), dict)
+
+    def test_contains_fa_url(self):
+        """Test that spec contains fa_url."""
+        result = purefa_argument_spec()
+        assert "fa_url" in result
+        assert result["fa_url"] == {}
+
+    def test_contains_api_token(self):
+        """Test that spec contains api_token with no_log."""
+        result = purefa_argument_spec()
+        assert "api_token" in result
+        assert result["api_token"]["no_log"] is True
+
+    def test_contains_disable_warnings(self):
+        """Test that spec contains disable_warnings with defaults."""
+        result = purefa_argument_spec()
+        assert result["disable_warnings"]["type"] == "bool"
+        assert result["disable_warnings"]["default"] is False
+
+    def test_all_expected_keys(self):
+        """Test that spec contains exactly the expected keys."""
+        result = purefa_argument_spec()
+        expected_keys = {
+            "fa_url",
+            "api_token",
+            "id_token",
+            "private_key_file",
+            "private_key_password",
+            "username",
+            "client_id",
+            "key_id",
+            "issuer",
+            "disable_warnings",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_token_auth_secrets_no_log(self):
+        """Secret token-auth params must be marked no_log."""
+        result = purefa_argument_spec()
+        assert result["id_token"]["no_log"] is True
+        assert result["private_key_password"]["no_log"] is True
+
+    def test_non_secret_params_no_log_false(self):
+        """Non-secret params that trip the no_log heuristic are silenced."""
+        result = purefa_argument_spec()
+        assert result["private_key_file"]["no_log"] is False
+        assert result["key_id"]["no_log"] is False
+
+
+class TestGetArray:
+    """Tests for get_array function."""
+
+    @patch("plugins.module_utils.purefa.flasharray.Client")
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", True)
+    def test_with_module_params(self, mock_client_class):
+        """Test get_array with api_token module parameters."""
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": "flasharray.example.com",
+            "api_token": "test-token-123",
+            "disable_warnings": False,
+        }
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        result = get_array(mock_module)
+
+        call_kwargs = mock_client_class.call_args[1]
+        assert call_kwargs["target"] == "flasharray.example.com"
+        assert call_kwargs["api_token"] == "test-token-123"
+        assert "user_agent" in call_kwargs
+        mock_client.get_hardware.assert_called_once()
+        assert result == mock_client
+
+    @patch("plugins.module_utils.purefa.flasharray.Client")
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefa.environ")
+    def test_with_environment_vars(self, mock_environ, mock_client_class):
+        """Test get_array with environment variables."""
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": None,
+            "api_token": None,
+            "disable_warnings": False,
+        }
+        env_vars = {
+            "PUREFA_URL": "env-flasharray.example.com",
+            "PUREFA_API": "env-token-456",
+        }
+        mock_environ.get.side_effect = env_vars.get
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        result = get_array(mock_module)
+
+        call_kwargs = mock_client_class.call_args[1]
+        assert call_kwargs["target"] == "env-flasharray.example.com"
+        assert call_kwargs["api_token"] == "env-token-456"
+        assert result == mock_client
+
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefa.environ")
+    def test_missing_credentials(self, mock_environ):
+        """Test that missing credentials causes failure."""
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": None,
+            "api_token": None,
+            "disable_warnings": False,
+        }
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+        mock_environ.get.return_value = None
+
+        try:
+            get_array(mock_module)
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "PUREFA_URL" in msg
+        assert "PUREFA_API" in msg
+
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", False)
+    def test_missing_pypureclient(self):
+        """Test that missing pypureclient causes failure."""
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": "flasharray.example.com",
+            "api_token": "test-token",
+            "disable_warnings": False,
+        }
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+
+        try:
+            get_array(mock_module)
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        assert "py-pure-client" in mock_module.fail_json.call_args[1]["msg"]
+
+    @patch("plugins.module_utils.purefa.flasharray.Client")
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", True)
+    def test_authentication_failure(self, mock_client_class):
+        """Test that authentication failure is handled."""
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": "flasharray.example.com",
+            "api_token": "invalid-token",
+            "disable_warnings": False,
+        }
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+        mock_client = Mock()
+        mock_client.get_hardware.side_effect = Exception("auth failed")
+        mock_client_class.return_value = mock_client
+
+        try:
+            get_array(mock_module)
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        assert (
+            "authentication failed" in mock_module.fail_json.call_args[1]["msg"].lower()
+        )
+
+    @patch("plugins.module_utils.purefa.flasharray.Client")
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefa.environ")
+    def test_with_id_token(self, mock_environ, mock_client_class):
+        """Test get_array authenticates with a pre-signed id_token."""
+        mock_environ.get.return_value = None
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": "flasharray.example.com",
+            "api_token": None,
+            "id_token": "eyJhbGciOiJSUzI1NiJ9.payload.sig",
+            "disable_warnings": False,
+        }
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        result = get_array(mock_module)
+
+        call_kwargs = mock_client_class.call_args[1]
+        assert call_kwargs["target"] == "flasharray.example.com"
+        assert call_kwargs["id_token"] == "eyJhbGciOiJSUzI1NiJ9.payload.sig"
+        assert "api_token" not in call_kwargs
+        assert result == mock_client
+
+    @patch("plugins.module_utils.purefa.flasharray.Client")
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefa.environ")
+    def test_with_private_key(self, mock_environ, mock_client_class):
+        """Test get_array authenticates with the private-key app flow."""
+        mock_environ.get.return_value = None
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": "flasharray.example.com",
+            "api_token": None,
+            "id_token": None,
+            "private_key_file": "/run/secrets/aap.pem",
+            "private_key_password": "s3cret",
+            "username": "automation",
+            "client_id": "cid-123",
+            "key_id": "kid-456",
+            "issuer": "AAP",
+            "disable_warnings": False,
+        }
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        result = get_array(mock_module)
+
+        call_kwargs = mock_client_class.call_args[1]
+        assert call_kwargs["target"] == "flasharray.example.com"
+        assert call_kwargs["private_key_file"] == "/run/secrets/aap.pem"
+        assert call_kwargs["private_key_password"] == "s3cret"
+        assert call_kwargs["username"] == "automation"
+        assert call_kwargs["client_id"] == "cid-123"
+        assert call_kwargs["key_id"] == "kid-456"
+        assert call_kwargs["issuer"] == "AAP"
+        assert "api_token" not in call_kwargs
+        assert result == mock_client
+
+    @patch("plugins.module_utils.purefa.flasharray.Client")
+    @patch("plugins.module_utils.purefa.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefa.environ")
+    def test_incomplete_private_key_set_fails(self, mock_environ, mock_client_class):
+        """An incomplete private-key set (no username) must fail cleanly."""
+        mock_module = Mock()
+        mock_module.params = {
+            "fa_url": "flasharray.example.com",
+            "api_token": None,
+            "id_token": None,
+            "private_key_file": "/run/secrets/aap.pem",
+            "private_key_password": None,
+            "username": None,  # missing -> not a complete set
+            "client_id": "cid-123",
+            "key_id": "kid-456",
+            "issuer": "AAP",
+            "disable_warnings": False,
+        }
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+        mock_environ.get.return_value = None
+
+        try:
+            get_array(mock_module)
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        mock_client_class.assert_not_called()


### PR DESCRIPTION
##### SUMMARY
Extend get_array() and purefa_argument_spec() to support the SDK's OAuth2 / API-client token flow as alternatives to a static api_token:
  - id_token: a pre-signed JWT exchanged by the array for an access token
  - private_key_file (+ client_id, key_id, issuer, username): SDK signs the identity token locally before exchange

Both modes require a matching API Client registered on the array (see purefa_apiclient) and are fully backwards compatible - existing api_token playbooks are unchanged. Adds matching PUREFA_* env vars, documents the options in the shared purestorage.fa doc fragment, and covers each auth branch with unit tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa.py