### PR TITLE
Fix/context fleet default

### DIFF
--- a/changelogs/fragments/1009_context_fleet_default.yaml
+++ b/changelogs/fragments/1009_context_fleet_default.yaml
@@ -5,3 +5,5 @@ bugfixes:
   - purefa_snap - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
   - purefa_vg - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
   - purefa_volume - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
+  - purefa_volume - Route all context-aware API calls through the shared api_helpers so context_names is only sent when a context is set, and fix an inverted version check on the pod-move path
+  - purefa_workload - Fail with a clear error when the array is not a member of a fleet, since the module requires a Fusion fleet environment

--- a/changelogs/fragments/1009_context_fleet_default.yaml
+++ b/changelogs/fragments/1009_context_fleet_default.yaml
@@ -1,0 +1,7 @@
+bugfixes:
+  - purefa_hg - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
+  - purefa_pg - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
+  - purefa_pgsnap - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
+  - purefa_snap - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
+  - purefa_vg - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
+  - purefa_volume - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases

--- a/changelogs/fragments/1009_context_fleet_default.yaml
+++ b/changelogs/fragments/1009_context_fleet_default.yaml
@@ -6,4 +6,6 @@ bugfixes:
   - purefa_vg - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
   - purefa_volume - Only default the context to the local array name when the array is a fleet member, so standalone arrays do not send fleet context that would fail on stricter Purity releases
   - purefa_volume - Route all context-aware API calls through the shared api_helpers so context_names is only sent when a context is set, and fix an inverted version check on the pod-move path
+  - purefa_pgsnap - Route context-aware API calls through the shared api_helpers so context_names is only sent when a context is set
+  - purefa_snap - Only send context_names when a context is set, so standalone arrays do not send fleet context that would fail on stricter Purity releases
   - purefa_workload - Fail with a clear error when the array is not a member of a fleet, since the module requires a Fusion fleet environment

--- a/plugins/modules/purefa_hg.py
+++ b/plugins/modules/purefa_hg.py
@@ -537,7 +537,9 @@ def main():
         and not module.params["context"]
     ):
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(array.get_arrays().items)[0].name
+        fleet_res = array.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(array.get_arrays().items)[0].name
     hostgroup = get_hostgroup(module, array)
 
     if module.params["host"]:

--- a/plugins/modules/purefa_pg.py
+++ b/plugins/modules/purefa_pg.py
@@ -972,7 +972,9 @@ def main():
         and not module.params["context"]
     ):
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(array.get_arrays().items)[0].name
+        fleet_res = array.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(array.get_arrays().items)[0].name
     if module.params["safe_mode"] and LooseVersion(
         RETENTION_LOCK_VERSION
     ) > LooseVersion(api_version):

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -963,7 +963,9 @@ def main():
     if not module.params["context"] and LooseVersion(
         CONTEXT_API_VERSION
     ) <= LooseVersion(api_version):
-        module.params["context"] = list(array.get_arrays().items)[0].name
+        fleet_res = array.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(array.get_arrays().items)[0].name
 
     pgroup = get_pgroup(module, array)
     if not pgroup:

--- a/plugins/modules/purefa_pgsnap.py
+++ b/plugins/modules/purefa_pgsnap.py
@@ -476,76 +476,54 @@ def create_pgsnapshot(module, array):
                     protection_group_snapshot=suffix,
                 )
         else:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                remote_target = (
-                    list(
-                        array.get_protection_groups(
-                            names=[module.params["name"]],
-                            context_names=[module.params["context"]],
-                        ).items
-                    )[0].target_count
-                    > 0
-                )
-            else:
-                remote_target = (
-                    list(
-                        array.get_protection_groups(names=[module.params["name"]]).items
-                    )[0].target_count
-                    > 0
-                )
+            remote_target = (
+                list(
+                    get_with_context(
+                        array,
+                        "get_protection_groups",
+                        CONTEXT_API_VERSION,
+                        module,
+                        names=[module.params["name"]],
+                    ).items
+                )[0].target_count
+                > 0
+            )
             if remote_target:
                 if module.params["now"]:
-                    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                        res = array.post_protection_group_snapshots(
-                            source_names=[module.params["name"]],
-                            apply_retention=module.params["apply_retention"],
-                            replicate_now=True,
-                            allow_throttle=module.params["throttle"],
-                            protection_group_snapshot=suffix,
-                            context_names=[module.params["context"]],
-                        )
-                    else:
-                        res = array.post_protection_group_snapshots(
-                            source_names=[module.params["name"]],
-                            apply_retention=module.params["apply_retention"],
-                            replicate_now=True,
-                            allow_throttle=module.params["throttle"],
-                            protection_group_snapshot=suffix,
-                        )
+                    res = post_with_context(
+                        array,
+                        "post_protection_group_snapshots",
+                        CONTEXT_API_VERSION,
+                        module,
+                        source_names=[module.params["name"]],
+                        apply_retention=module.params["apply_retention"],
+                        replicate_now=True,
+                        allow_throttle=module.params["throttle"],
+                        protection_group_snapshot=suffix,
+                    )
                 else:
-                    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                        res = array.post_protection_group_snapshots(
-                            source_names=[module.params["name"]],
-                            apply_retention=module.params["apply_retention"],
-                            allow_throttle=module.params["throttle"],
-                            protection_group_snapshot=suffix,
-                            replicate=module.params["remote"],
-                            context_names=[module.params["context"]],
-                        )
-                    else:
-                        res = array.post_protection_group_snapshots(
-                            source_names=[module.params["name"]],
-                            apply_retention=module.params["apply_retention"],
-                            allow_throttle=module.params["throttle"],
-                            protection_group_snapshot=suffix,
-                            replicate=module.params["remote"],
-                        )
+                    res = post_with_context(
+                        array,
+                        "post_protection_group_snapshots",
+                        CONTEXT_API_VERSION,
+                        module,
+                        source_names=[module.params["name"]],
+                        apply_retention=module.params["apply_retention"],
+                        allow_throttle=module.params["throttle"],
+                        protection_group_snapshot=suffix,
+                        replicate=module.params["remote"],
+                    )
             else:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.post_protection_group_snapshots(
-                        source_names=[module.params["name"]],
-                        apply_retention=module.params["apply_retention"],
-                        allow_throttle=module.params["throttle"],
-                        protection_group_snapshot=suffix,
-                        context_names=[module.params["context"]],
-                    )
-                else:
-                    res = array.post_protection_group_snapshots(
-                        source_names=[module.params["name"]],
-                        apply_retention=module.params["apply_retention"],
-                        allow_throttle=module.params["throttle"],
-                        protection_group_snapshot=suffix,
-                    )
+                res = post_with_context(
+                    array,
+                    "post_protection_group_snapshots",
+                    CONTEXT_API_VERSION,
+                    module,
+                    source_names=[module.params["name"]],
+                    apply_retention=module.params["apply_retention"],
+                    allow_throttle=module.params["throttle"],
+                    protection_group_snapshot=suffix,
+                )
 
         check_response(
             res, module, f"Snapshot of pgroup {module.params['name']} failed"
@@ -630,35 +608,32 @@ def restore_pgsnapvolume(module, array):
                     add_to_protection_groups=add_to_pgs,
                 )
             else:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    if module.params["overwrite"]:
-                        res = array.post_volumes(
-                            names=[module.params["target"]],
-                            volume=VolumePost(source=Reference(name=source_volume)),
-                            overwrite=module.params["overwrite"],
-                            context_names=[module.params["context"]],
-                        )
-                    else:
-                        res = array.post_volumes(
-                            names=[module.params["target"]],
-                            volume=VolumePost(source=Reference(name=source_volume)),
-                            overwrite=module.params["overwrite"],
-                        )
+                if module.params["overwrite"]:
+                    # Overwrite path is identical across versions apart from
+                    # context; the helper adds context_names only when set.
+                    res = post_with_context(
+                        array,
+                        "post_volumes",
+                        CONTEXT_API_VERSION,
+                        module,
+                        names=[module.params["target"]],
+                        volume=VolumePost(source=Reference(name=source_volume)),
+                        overwrite=module.params["overwrite"],
+                    )
+                elif LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
+                    res = array.post_volumes(
+                        names=[module.params["target"]],
+                        volume=VolumePost(source=Reference(name=source_volume)),
+                        overwrite=module.params["overwrite"],
+                    )
                 else:
-                    if module.params["overwrite"]:
-                        res = array.post_volumes(
-                            names=[module.params["target"]],
-                            volume=VolumePost(source=Reference(name=source_volume)),
-                            overwrite=module.params["overwrite"],
-                        )
-                    else:
-                        res = array.post_volumes(
-                            names=[module.params["target"]],
-                            volume=VolumePost(source=Reference(name=source_volume)),
-                            with_default_protection=module.params[
-                                "with_default_protection"
-                            ],
-                        )
+                    res = array.post_volumes(
+                        names=[module.params["target"]],
+                        volume=VolumePost(source=Reference(name=source_volume)),
+                        with_default_protection=module.params[
+                            "with_default_protection"
+                        ],
+                    )
         else:
             res = array.post_volumes(
                 names=[module.params["target"]],

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -357,7 +357,10 @@ def create_snapshot(module, array):
             module.params["suffix"] = None
         changed = True
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = array.post_remote_volume_snapshots(
                     source_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -393,7 +396,10 @@ def create_snapshot(module, array):
         changed = True
         if not module.check_mode:
             if LooseVersion(THROTTLE_API) <= LooseVersion(api_version):
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = array.post_volume_snapshots(
                         allow_throttle=module.params["throttle"],
                         context_names=[module.params["context"]],

--- a/plugins/modules/purefa_snap.py
+++ b/plugins/modules/purefa_snap.py
@@ -726,7 +726,9 @@ def main():
         and not module.params["context"]
     ):
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(array.get_arrays().items)[0].name
+        fleet_res = array.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(array.get_arrays().items)[0].name
     if module.params["offload"]:
         if not _check_offload(module, array) and not _check_target(module, array):
             module.fail_json(

--- a/plugins/modules/purefa_vg.py
+++ b/plugins/modules/purefa_vg.py
@@ -687,7 +687,9 @@ def main():
         and not module.params["context"]
     ):
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(array.get_arrays().items)[0].name
+        fleet_res = array.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(array.get_arrays().items)[0].name
     vgroup = get_vgroup(module, array)
     xvgroup = get_pending_vgroup(module, array)
 

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -1887,7 +1887,9 @@ def main():
         and not module.params["context"]
     ):
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(array.get_arrays().items)[0].name
+        fleet_res = array.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(array.get_arrays().items)[0].name
 
     if module.params["bw_qos"]:
         bw_qos = int(human_to_bytes(module.params["bw_qos"]))

--- a/plugins/modules/purefa_volume.py
+++ b/plugins/modules/purefa_volume.py
@@ -350,6 +350,10 @@ from ansible_collections.purestorage.flasharray.plugins.module_utils.version imp
 )
 from ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers import (
     check_response,
+    get_with_context,
+    post_with_context,
+    patch_with_context,
+    delete_with_context,
 )
 
 PURE_OUI = "naa.624a9370"
@@ -361,14 +365,11 @@ CONTEXT_API_VERSION = "2.38"
 def _volfact(module, array, volume_name):
     api_version = array.get_rest_version()
     if not module.check_mode:
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            volume_data = list(
-                array.get_volumes(
-                    names=[volume_name], context_names=[module.params["context"]]
-                ).items
-            )[0]
-        else:
-            volume_data = list(array.get_volumes(names=[volume_name]).items)[0]
+        volume_data = list(
+            get_with_context(
+                array, "get_volumes", CONTEXT_API_VERSION, module, names=[volume_name]
+            ).items
+        )[0]
         volfact = {
             volume_name: {
                 "size": volume_data.provisioned,
@@ -411,10 +412,9 @@ def get_pod(module, array):
     """Get ActiveCluster Pod"""
     api_version = array.get_rest_version()
     pod_name = "::".join(module.params["pgroup"].split("::")[:-1])
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_pods(names=[pod_name], context_names=[module.params["context"]])
-    else:
-        res = array.get_pods(names=[pod_name])
+    res = get_with_context(
+        array, "get_pods", CONTEXT_API_VERSION, module, names=[pod_name]
+    )
     if res.status_code == 200:
         return list(res.items)[0]
     return None
@@ -423,12 +423,13 @@ def get_pod(module, array):
 def get_pending_pgroup(module, array):
     """Get Protection Group"""
     api_version = array.get_rest_version()
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_protection_groups(
-            names=[module.params["pgroup"]], context_names=[module.params["context"]]
-        )
-    else:
-        res = array.get_protection_groups(names=[module.params["pgroup"]])
+    res = get_with_context(
+        array,
+        "get_protection_groups",
+        CONTEXT_API_VERSION,
+        module,
+        names=[module.params["pgroup"]],
+    )
     if res.status_code == 200:
         pgroup = list(res.items)[0]
         if pgroup.destroyed:
@@ -439,12 +440,13 @@ def get_pending_pgroup(module, array):
 def get_pgroup(module, array):
     """Get Protection Group"""
     api_version = array.get_rest_version()
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_protection_groups(
-            names=[module.params["pgroup"]], context_names=[module.params["context"]]
-        )
-    else:
-        res = array.get_protection_groups(names=[module.params["pgroup"]])
+    res = get_with_context(
+        array,
+        "get_protection_groups",
+        CONTEXT_API_VERSION,
+        module,
+        names=[module.params["pgroup"]],
+    )
     if res.status_code == 200:
         return list(res.items)[0]
     return None
@@ -453,12 +455,9 @@ def get_pgroup(module, array):
 def pg_exists(module, pgs, array):
     """Get Protection Group"""
     api_version = array.get_rest_version()
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_protection_groups(
-            names=[pgs], context_names=[module.params["context"]]
-        )
-    else:
-        res = array.get_protection_groups(names=[pgs])
+    res = get_with_context(
+        array, "get_protection_groups", CONTEXT_API_VERSION, module, names=[pgs]
+    )
     return bool(res.status_code == 200)
 
 
@@ -474,12 +473,9 @@ def get_multi_volumes(module, array):
             + str(vol_num).zfill(module.params["digits"])
             + module.params["suffix"]
         )
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_volumes(
-            names=names, destroyed=False, context_names=[module.params["context"]]
-        )
-    else:
-        res = array.get_volumes(names=names, destroyed=False)
+    res = get_with_context(
+        array, "get_volumes", CONTEXT_API_VERSION, module, names=names, destroyed=False
+    )
     if res.status_code == 200:
         return list(res.items)[0]
     return None
@@ -488,14 +484,14 @@ def get_multi_volumes(module, array):
 def get_volume(module, array):
     """Return Volume or None"""
     api_version = array.get_rest_version()
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_volumes(
-            names=[module.params["name"]],
-            destroyed=False,
-            context_names=[module.params["context"]],
-        )
-    else:
-        res = array.get_volumes(names=[module.params["name"]], destroyed=False)
+    res = get_with_context(
+        array,
+        "get_volumes",
+        CONTEXT_API_VERSION,
+        module,
+        names=[module.params["name"]],
+        destroyed=False,
+    )
     if res.status_code == 200:
         return list(res.items)[0]
     return None
@@ -504,10 +500,9 @@ def get_volume(module, array):
 def get_endpoint(module, name, array):
     """Return Endpoint or None"""
     api_version = array.get_rest_version()
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_volumes(names=[name], context_names=[module.params["context"]])
-    else:
-        res = array.get_volumes(names=[name])
+    res = get_with_context(
+        array, "get_volumes", CONTEXT_API_VERSION, module, names=[name]
+    )
     if res.status_code == 200:
         volume = list(res.items)[0]
         if volume.subtype == "protocol_endpoint":
@@ -518,14 +513,14 @@ def get_endpoint(module, name, array):
 def get_destroyed_volume(module, array):
     """Return Destroyed Volume or None"""
     api_version = array.get_rest_version()
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_volumes(
-            names=[module.params["name"]],
-            destroyed=True,
-            context_names=[module.params["context"]],
-        )
-    else:
-        res = array.get_volumes(names=[module.params["name"]], destroyed=True)
+    res = get_with_context(
+        array,
+        "get_volumes",
+        CONTEXT_API_VERSION,
+        module,
+        names=[module.params["name"]],
+        destroyed=True,
+    )
     if res.status_code == 200:
         return list(res.items)[0]
     return None
@@ -534,12 +529,13 @@ def get_destroyed_volume(module, array):
 def get_target(module, array):
     """Return Volume or None"""
     api_version = array.get_rest_version()
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_volumes(
-            names=[module.params["target"]], context_names=[module.params["context"]]
-        )
-    else:
-        res = array.get_volumes(names=[module.params["target"]])
+    res = get_with_context(
+        array,
+        "get_volumes",
+        CONTEXT_API_VERSION,
+        module,
+        names=[module.params["target"]],
+    )
     if res.status_code == 200:
         return list(res.items)[0]
     return None
@@ -549,12 +545,9 @@ def check_vgroup(module, array):
     """Check is the requested VG to create volume in exists"""
     api_version = array.get_rest_version()
     vg_name = module.params["name"].split("/")[0]
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_volume_groups(
-            names=[vg_name], context_names=[module.params["context"]]
-        )
-    else:
-        res = array.get_volume_groups(names=[vg_name])
+    res = get_with_context(
+        array, "get_volume_groups", CONTEXT_API_VERSION, module, names=[vg_name]
+    )
     return bool(res.status_code == 200)
 
 
@@ -562,10 +555,9 @@ def check_pod(module, array):
     """Check is the requested pod to create volume in exists"""
     api_version = array.get_rest_version()
     pod_name = "::".join(module.params["name"].split("::")[:-1])
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        res = array.get_pods(names=[pod_name], context_names=[module.params["context"]])
-    else:
-        res = array.get_pods(names=[pod_name])
+    res = get_with_context(
+        array, "get_pods", CONTEXT_API_VERSION, module, names=[pod_name]
+    )
     return bool(res.status_code == 200)
 
 
@@ -589,14 +581,11 @@ def create_volume(module, array):
                 )
             )
         pod_name = "::".join(module.params["name"].split("::")[:-1])
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            res = list(
-                array.get_pods(
-                    names=[pod_name], context_names=[module.params["context"]]
-                ).items
-            )[0]
-        else:
-            res = list(array.get_pods(names=[pod_name]).items)[0]
+        res = list(
+            get_with_context(
+                array, "get_pods", CONTEXT_API_VERSION, module, names=[pod_name]
+            ).items
+        )[0]
         if res.promotion_status == "demoted":
             module.fail_json(msg="Volume cannot be created in a demoted pod")
     if not module.params["size"]:
@@ -605,112 +594,74 @@ def create_volume(module, array):
         if module.params["bw_qos"] and not module.params["iops_qos"]:
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.post_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePost(
-                            provisioned=int(human_to_bytes(module.params["size"])),
-                            qos=Qos(
-                                bandwidth_limit=int(
-                                    human_to_bytes(module.params["bw_qos"])
-                                )
-                            ),
+                res = post_with_context(
+                    array,
+                    "post_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePost(
+                        provisioned=int(human_to_bytes(module.params["size"])),
+                        qos=Qos(
+                            bandwidth_limit=int(human_to_bytes(module.params["bw_qos"]))
                         ),
-                        context_names=[module.params["context"]],
-                    )
-                else:
-                    res = array.post_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePost(
-                            provisioned=int(human_to_bytes(module.params["size"])),
-                            qos=Qos(
-                                bandwidth_limit=int(
-                                    human_to_bytes(module.params["bw_qos"])
-                                )
-                            ),
-                        ),
-                    )
+                    ),
+                )
                 check_response(
                     res, module, f"Volume {module.params['name']} creation failed"
                 )
         elif module.params["iops_qos"] and not module.params["bw_qos"]:
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.post_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePost(
-                            provisioned=int(human_to_bytes(module.params["size"])),
-                            qos=Qos(iops_limit=int(module.params["iops_qos"])),
-                        ),
-                        context_names=[module.params["context"]],
-                    )
-                else:
-                    res = array.post_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePost(
-                            provisioned=int(human_to_bytes(module.params["size"])),
-                            qos=Qos(iops_limit=int(module.params["iops_qos"])),
-                        ),
-                    )
+                res = post_with_context(
+                    array,
+                    "post_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePost(
+                        provisioned=int(human_to_bytes(module.params["size"])),
+                        qos=Qos(iops_limit=int(module.params["iops_qos"])),
+                    ),
+                )
                 check_response(
                     res, module, f"Volume {module.params['name']} creation failed"
                 )
         else:
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.post_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePost(
-                            provisioned=int(human_to_bytes(module.params["size"])),
-                            qos=Qos(
-                                iops_limit=int(
-                                    human_to_real(module.params["iops_qos"])
-                                ),
-                                bandwidth_limit=int(
-                                    human_to_bytes(module.params["bw_qos"])
-                                ),
+                res = post_with_context(
+                    array,
+                    "post_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePost(
+                        provisioned=int(human_to_bytes(module.params["size"])),
+                        qos=Qos(
+                            iops_limit=int(human_to_real(module.params["iops_qos"])),
+                            bandwidth_limit=int(
+                                human_to_bytes(module.params["bw_qos"])
                             ),
                         ),
-                        context_names=[module.params["context"]],
-                    )
-                else:
-                    res = array.post_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePost(
-                            provisioned=int(human_to_bytes(module.params["size"])),
-                            qos=Qos(
-                                iops_limit=int(
-                                    human_to_real(module.params["iops_qos"])
-                                ),
-                                bandwidth_limit=int(
-                                    human_to_bytes(module.params["bw_qos"])
-                                ),
-                            ),
-                        ),
-                    )
+                    ),
+                )
                 check_response(
                     res, module, f"Volume {module.params['name']} creation failed"
                 )
     else:
         changed = True
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.post_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePost(
-                        provisioned=int(human_to_bytes(module.params["size"]))
-                    ),
-                    context_names=[module.params["context"]],
-                )
-            else:
-                res = array.post_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePost(
-                        provisioned=int(human_to_bytes(module.params["size"]))
-                    ),
-                )
+            res = post_with_context(
+                array,
+                "post_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                volume=VolumePost(
+                    provisioned=int(human_to_bytes(module.params["size"]))
+                ),
+            )
             check_response(
                 res, module, f"Volume {module.params['name']} creation failed"
             )
@@ -718,32 +669,25 @@ def create_volume(module, array):
         volume = VolumePatch(requested_promotion_state=module.params["promotion_state"])
         changed = True
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    volume=volume,
-                    context_names=[module.params["context"]],
-                )
-            else:
-                res = array.patch_volumes(names=[module.params["name"]], volume=volume)
+            res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                volume=volume,
+            )
             if res.status_code != 200:
                 message = res.errors[0].message
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(destroyed=True),
-                        context_names=[module.params["context"]],
-                    )
-                    array.delete_volumes(
-                        names=[module.params["name"]],
-                        context_names=[module.params["context"]],
-                    )
-                else:
-                    array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(destroyed=True),
-                    )
-                    array.delete_volumes(names=[module.params["name"]])
+                patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePatch(destroyed=True),
+                )
+                array.delete_volumes(names=[module.params["name"]])
                 module.fail_json(
                     msg="Failed to set Promotion State for volume {0}. Error: {1}".format(
                         module.params["name"],
@@ -757,32 +701,25 @@ def create_volume(module, array):
                 priority_adjustment_value=module.params["priority_value"],
             )
         )
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            res = array.patch_volumes(
-                names=[module.params["name"]],
-                volume=volume,
-                context_names=[module.params["context"]],
-            )
-        else:
-            res = array.patch_volumes(names=[module.params["name"]], volume=volume)
+        res = patch_with_context(
+            array,
+            "patch_volumes",
+            CONTEXT_API_VERSION,
+            module,
+            names=[module.params["name"]],
+            volume=volume,
+        )
         if res.status_code != 200:
             message = res.errors[0].message
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                array.patch_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePatch(destroyed=True),
-                    context_names=[module.params["context"]],
-                )
-                array.delete_volumes(
-                    names=[module.params["name"]],
-                    context_names=[module.params["context"]],
-                )
-            else:
-                array.patch_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePatch(destroyed=True),
-                )
-                array.delete_volumes(names=[module.params["name"]])
+            patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                volume=VolumePatch(destroyed=True),
+            )
+            array.delete_volumes(names=[module.params["name"]])
             module.fail_json(
                 msg="Failed to set DMM Priority Adjustment on volume {0}. Error: {1}".format(
                     module.params["name"], message
@@ -791,21 +728,14 @@ def create_volume(module, array):
     if module.params["pgroup"]:
         changed = True
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    add_to_protection_groups=ReferenceType(
-                        name=module.params["pgroup"]
-                    ),
-                    context_names=[module.params["context"]],
-                )
-            else:
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    add_to_protection_groups=ReferenceType(
-                        name=module.params["pgroup"]
-                    ),
-                )
+            res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                add_to_protection_groups=ReferenceType(name=module.params["pgroup"]),
+            )
             if res.status_code != 200:
                 module.warn_json(
                     "Failed to add {0} to protection group {1}. Error: {2}".format(
@@ -843,22 +773,15 @@ def create_multi_volume(module, array, single=False):
                 )
             )
         pod_name = "::".join(module.params["name"].split("::")[:-1])
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            if (
-                list(
-                    array.get_pods(
-                        names=[pod_name], context_names=[module.params["context"]]
-                    ).items
-                )[0].promotion_status
-                == "demoted"
-            ):
-                module.fail_json(msg="Volume cannot be created in a demoted pod")
-        else:
-            if (
-                list(array.get_pods(names=[pod_name]).items)[0].promotion_status
-                == "demoted"
-            ):
-                module.fail_json(msg="Volume cannot be created in a demoted pod")
+        if (
+            list(
+                get_with_context(
+                    array, "get_pods", CONTEXT_API_VERSION, module, names=[pod_name]
+                ).items
+            )[0].promotion_status
+            == "demoted"
+        ):
+            module.fail_json(msg="Volume cannot be created in a demoted pod")
     if not single:
         for vol_num in range(
             module.params["start"], module.params["count"] + module.params["start"]
@@ -957,23 +880,15 @@ def create_multi_volume(module, array, single=False):
                     msg="Cannot specify a remote fleet member and default protection group"
                 )
             else:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.post_volumes(
-                        names=names,
-                        volume=vols,
-                        context_names=[module.params["context"]],
-                        with_default_protection=module.params[
-                            "with_default_protection"
-                        ],
-                    )
-                else:
-                    res = array.post_volumes(
-                        names=names,
-                        volume=vols,
-                        with_default_protection=module.params[
-                            "with_default_protection"
-                        ],
-                    )
+                res = post_with_context(
+                    array,
+                    "post_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=names,
+                    volume=vols,
+                    with_default_protection=module.params["with_default_protection"],
+                )
         check_response(
             res,
             module,
@@ -983,28 +898,24 @@ def create_multi_volume(module, array, single=False):
             volume = VolumePatch(
                 requested_promotion_state=module.params["promotion_state"]
             )
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                prom_res = array.patch_volumes(
-                    names=names,
-                    volume=volume,
-                    context_names=[module.params["context"]],
-                )
-            else:
-                prom_res = array.patch_volumes(names=names, volume=volume)
+            prom_res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=names,
+                volume=volume,
+            )
             if prom_res.status_code != 200:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    array.patch_volumes(
-                        names=names,
-                        context_names=[module.params["context"]],
-                        volume=VolumePatch(destroyed=True),
-                    )
-                    array.delete_volumes(names=names)
-                else:
-                    array.patch_volumes(
-                        names=names,
-                        volume=VolumePatch(destroyed=True),
-                    )
-                    array.delete_volumes(names=names)
+                patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=names,
+                    volume=VolumePatch(destroyed=True),
+                )
+                array.delete_volumes(names=names)
                 module.warn(
                     "Failed to set promotion status on volumes. Error: {0}".format(
                         prom_res.errors[0].message
@@ -1017,28 +928,24 @@ def create_multi_volume(module, array, single=False):
                     priority_adjustment_value=module.params["priority_value"],
                 )
             )
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                prio_res = array.patch_volumes(
-                    names=names,
-                    volume=volume,
-                    context_names=[module.params["context"]],
-                )
-            else:
-                prio_res = array.patch_volumes(names=names, volume=volume)
+            prio_res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=names,
+                volume=volume,
+            )
             if prio_res.status_code != 200:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    array.patch_volumes(
-                        names=names,
-                        context_names=[module.params["context"]],
-                        volume=VolumePatch(destroyed=True),
-                    )
-                    array.delete_volumes(names=names)
-                else:
-                    array.patch_volumes(
-                        names=names,
-                        volume=VolumePatch(destroyed=True),
-                    )
-                    array.delete_volumes(names=names)
+                patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=names,
+                    volume=VolumePatch(destroyed=True),
+                )
+                array.delete_volumes(names=names)
                 module.fail_json(
                     msg="Failed to set DMM Priority Adjustment on volumes. Error: {0}".format(
                         prio_res.errors[0].message
@@ -1092,51 +999,30 @@ def copy_from_volume(module, array):
                     add_to_pgs = []
                     for add_pg in module.params["add_to_pgs"]:
                         add_to_pgs.append(ReferenceType(name=add_pg))
-                    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                        res = array.post_volumes(
-                            with_default_protection=module.params[
-                                "with_default_protection"
-                            ],
-                            add_to_protection_groups=add_to_pgs,
-                            context_names=[module.params["context"]],
-                            names=[module.params["target"]],
-                            volume=VolumePost(
-                                source=Reference(name=module.params["name"])
-                            ),
-                        )
-                    else:
-                        res = array.post_volumes(
-                            with_default_protection=module.params[
-                                "with_default_protection"
-                            ],
-                            add_to_protection_groups=add_to_pgs,
-                            names=[module.params["target"]],
-                            volume=VolumePost(
-                                source=Reference(name=module.params["name"])
-                            ),
-                        )
+                    res = post_with_context(
+                        array,
+                        "post_volumes",
+                        CONTEXT_API_VERSION,
+                        module,
+                        with_default_protection=module.params[
+                            "with_default_protection"
+                        ],
+                        add_to_protection_groups=add_to_pgs,
+                        names=[module.params["target"]],
+                        volume=VolumePost(source=Reference(name=module.params["name"])),
+                    )
                 else:
-                    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                        res = array.post_volumes(
-                            with_default_protection=module.params[
-                                "with_default_protection"
-                            ],
-                            names=[module.params["target"]],
-                            context_names=[module.params["context"]],
-                            volume=VolumePost(
-                                source=Reference(name=module.params["name"])
-                            ),
-                        )
-                    else:
-                        res = array.post_volumes(
-                            with_default_protection=module.params[
-                                "with_default_protection"
-                            ],
-                            names=[module.params["target"]],
-                            volume=VolumePost(
-                                source=Reference(name=module.params["name"])
-                            ),
-                        )
+                    res = post_with_context(
+                        array,
+                        "post_volumes",
+                        CONTEXT_API_VERSION,
+                        module,
+                        with_default_protection=module.params[
+                            "with_default_protection"
+                        ],
+                        names=[module.params["target"]],
+                        volume=VolumePost(source=Reference(name=module.params["name"])),
+                    )
 
                 check_response(
                     res,
@@ -1156,19 +1042,15 @@ def copy_from_volume(module, array):
     elif tgt is not None and module.params["overwrite"]:
         changed = True
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.post_volumes(
-                    names=[module.params["target"]],
-                    volume=VolumePost(source=Reference(name=module.params["name"])),
-                    context_names=[module.params["context"]],
-                    overwrite=module.params["overwrite"],
-                )
-            else:
-                res = array.post_volumes(
-                    names=[module.params["target"]],
-                    volume=VolumePost(source=Reference(name=module.params["name"])),
-                    overwrite=module.params["overwrite"],
-                )
+            res = post_with_context(
+                array,
+                "post_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["target"]],
+                volume=VolumePost(source=Reference(name=module.params["name"])),
+                overwrite=module.params["overwrite"],
+            )
             check_response(
                 res,
                 module,
@@ -1193,14 +1075,15 @@ def update_volume(module, array):
         and module.params["add_to_pgs"]
     ):
         module.fail_json(msg="For Purity//FA 6.3.4 or lower, use pgroup parameter")
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        vol = list(
-            array.get_volumes(
-                names=[module.params["name"]], context_names=[module.params["context"]]
-            ).items
-        )[0]
-    else:
-        vol = list(array.get_volumes(names=[module.params["name"]]).items)[0]
+    vol = list(
+        get_with_context(
+            array,
+            "get_volumes",
+            CONTEXT_API_VERSION,
+            module,
+            names=[module.params["name"]],
+        ).items
+    )[0]
     vol_qos = vol.qos
     if not hasattr(vol_qos, "bandwidth_limit"):
         vol.qos.bandwidth_limit = 549755813888
@@ -1211,21 +1094,16 @@ def update_volume(module, array):
             if human_to_bytes(module.params["size"]) > vol.provisioned:
                 changed = True
                 if not module.check_mode:
-                    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                        res = array.patch_volumes(
-                            names=[module.params["name"]],
-                            context_names=[module.params["context"]],
-                            volume=VolumePatch(
-                                provisioned=int(human_to_bytes(module.params["size"]))
-                            ),
-                        )
-                    else:
-                        res = array.patch_volumes(
-                            names=[module.params["name"]],
-                            volume=VolumePatch(
-                                provisioned=int(human_to_bytes(module.params["size"]))
-                            ),
-                        )
+                    res = patch_with_context(
+                        array,
+                        "patch_volumes",
+                        CONTEXT_API_VERSION,
+                        module,
+                        names=[module.params["name"]],
+                        volume=VolumePatch(
+                            provisioned=int(human_to_bytes(module.params["size"]))
+                        ),
+                    )
                     check_response(
                         res, module, f"Volume {module.params['name']} resize failed"
                     )
@@ -1235,17 +1113,14 @@ def update_volume(module, array):
         if module.params["bw_qos"] == "0":
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.patch_volumes(
-                        context_names=[module.params["context"]],
-                        names=[module.params["name"]],
-                        volume=VolumePatch(qos=Qos(bandwidth_limit=549755813888)),
-                    )
-                else:
-                    res = array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(qos=Qos(bandwidth_limit=549755813888)),
-                    )
+                res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePatch(qos=Qos(bandwidth_limit=549755813888)),
+                )
                 check_response(
                     res,
                     module,
@@ -1254,29 +1129,18 @@ def update_volume(module, array):
         else:
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.patch_volumes(
-                        names=[module.params["name"]],
-                        context_names=[module.params["context"]],
-                        volume=VolumePatch(
-                            qos=Qos(
-                                bandwidth_limit=int(
-                                    human_to_bytes(module.params["bw_qos"])
-                                )
-                            )
-                        ),
-                    )
-                else:
-                    res = array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(
-                            qos=Qos(
-                                bandwidth_limit=int(
-                                    human_to_bytes(module.params["bw_qos"])
-                                )
-                            )
-                        ),
-                    )
+                res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePatch(
+                        qos=Qos(
+                            bandwidth_limit=int(human_to_bytes(module.params["bw_qos"]))
+                        )
+                    ),
+                )
                 check_response(
                     res,
                     module,
@@ -1288,17 +1152,14 @@ def update_volume(module, array):
         if module.params["iops_qos"] == "0":
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.patch_volumes(
-                        context_names=[module.params["context"]],
-                        names=[module.params["name"]],
-                        volume=VolumePatch(qos=Qos(iops_limit=100000000)),
-                    )
-                else:
-                    res = array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(qos=Qos(iops_limit=100000000)),
-                    )
+                res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePatch(qos=Qos(iops_limit=100000000)),
+                )
                 check_response(
                     res,
                     module,
@@ -1307,25 +1168,18 @@ def update_volume(module, array):
         else:
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.patch_volumes(
-                        context_names=[module.params["context"]],
-                        names=[module.params["name"]],
-                        volume=VolumePatch(
-                            qos=Qos(
-                                iops_limit=int(human_to_real(module.params["iops_qos"]))
-                            )
-                        ),
-                    )
-                else:
-                    res = array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(
-                            qos=Qos(
-                                iops_limit=int(human_to_real(module.params["iops_qos"]))
-                            )
-                        ),
-                    )
+                res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePatch(
+                        qos=Qos(
+                            iops_limit=int(human_to_real(module.params["iops_qos"]))
+                        )
+                    ),
+                )
                 check_response(
                     res,
                     module,
@@ -1338,16 +1192,14 @@ def update_volume(module, array):
             )
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.patch_volumes(
-                        context_names=[module.params["context"]],
-                        names=[module.params["name"]],
-                        volume=volume_patch,
-                    )
-                else:
-                    res = array.patch_volumes(
-                        names=[module.params["name"]], volume=volume_patch
-                    )
+                res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=volume_patch,
+                )
                 check_response(
                     res,
                     module,
@@ -1387,16 +1239,14 @@ def update_volume(module, array):
         if change_prio:
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    prio_res = array.patch_volumes(
-                        context_names=[module.params["context"]],
-                        names=[module.params["name"]],
-                        volume=volumepatch,
-                    )
-                else:
-                    prio_res = array.patch_volumes(
-                        names=[module.params["name"]], volume=volumepatch
-                    )
+                prio_res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=volumepatch,
+                )
                 check_response(
                     prio_res,
                     module,
@@ -1404,35 +1254,28 @@ def update_volume(module, array):
                 )
     if module.params["add_to_pgs"]:
         pgs_now = []
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            current_pgs = list(
-                array.get_protection_groups_volumes(
-                    context_names=[module.params["context"]],
-                    member_names=[module.params["name"]],
-                ).items
-            )
-        else:
-            current_pgs = list(
-                array.get_protection_groups_volumes(
-                    member_names=[module.params["name"]]
-                ).items
-            )
+        current_pgs = list(
+            get_with_context(
+                array,
+                "get_protection_groups_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                member_names=[module.params["name"]],
+            ).items
+        )
         for current_pg in current_pgs:
             pgs_now.append(current_pg.group.name)
         new_pgs = list(filter(lambda x: x not in pgs_now, module.params["add_to_pgs"]))
         if new_pgs:
             changed = True
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.post_volumes_protection_groups(
-                    member_names=[module.params["name"]],
-                    group_names=new_pgs,
-                    context_names=[module.params["context"]],
-                )
-            else:
-                res = array.post_volumes_protection_groups(
-                    member_names=[module.params["name"]],
-                    group_names=new_pgs,
-                )
+            res = post_with_context(
+                array,
+                "post_volumes_protection_groups",
+                CONTEXT_API_VERSION,
+                module,
+                member_names=[module.params["name"]],
+                group_names=new_pgs,
+            )
             check_response(
                 res,
                 module,
@@ -1458,31 +1301,25 @@ def rename_volume(module, array):
         target_name = vgroup_name + "/" + module.params["rename"]
     else:
         target_name = module.params["rename"]
-    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-        target_exists = bool(
-            array.get_volumes(
-                names=[target_name], context_names=[module.params["context"]]
-            ).status_code
-            == 200
-        )
-    else:
-        target_exists = bool(array.get_volumes(names=[target_name]).status_code == 200)
+    target_exists = bool(
+        get_with_context(
+            array, "get_volumes", CONTEXT_API_VERSION, module, names=[target_name]
+        ).status_code
+        == 200
+    )
     if target_exists:
         module.fail_json(msg="Target volume {0} already exists.".format(target_name))
     else:
         changed = True
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    context_names=[module.params["context"]],
-                    volume=VolumePatch(name=module.params["rename"]),
-                )
-            else:
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePatch(name=module.params["rename"]),
-                )
+            res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                volume=VolumePatch(name=module.params["rename"]),
+            )
             check_response(
                 res,
                 module,
@@ -1513,92 +1350,72 @@ def move_volume(module, array):
                 module.fail_json(
                     msg="Source and destination [local] cannot be the same."
                 )
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            target_exists = bool(
-                array.get_volumes(
-                    names=[volume_name], context_names=[module.params["context"]]
-                ).status_code
-                == 200
-            )
-        else:
-            target_exists = bool(
-                array.get_volumes(names=[volume_name]).status_code == 200
-            )
+        target_exists = bool(
+            get_with_context(
+                array, "get_volumes", CONTEXT_API_VERSION, module, names=[volume_name]
+            ).status_code
+            == 200
+        )
         if target_exists:
             module.fail_json(msg="Target volume {0} already exists".format(volume_name))
     else:
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            pod_exists = bool(
-                array.get_pods(
-                    names=[module.params["move"]],
-                    context_names=[module.params["context"]],
-                ).status_code
-                == 200
-            )
-        else:
-            pod_exists = bool(
-                array.get_pods(names=[module.params["move"]]).status_code == 200
-            )
+        pod_exists = bool(
+            get_with_context(
+                array,
+                "get_pods",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["move"]],
+            ).status_code
+            == 200
+        )
         if pod_exists:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                pod = list(
-                    array.get_pods(
-                        names=[module.params["move"]],
-                        context_names=[module.params["context"]],
-                    ).items
-                )[0]
-            else:
-                pod = list(array.get_pods(names=[module.params["move"]]).items)[0]
+            pod = list(
+                get_with_context(
+                    array,
+                    "get_pods",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["move"]],
+                ).items
+            )[0]
             if pod.array_count > 1:
                 module.fail_json(msg="Volume cannot be moved into a stretched pod")
             if pod.link_target_count != 0:
                 module.fail_json(msg="Volume cannot be moved into a linked source pod")
             if pod.promotion_status == "demoted":
                 module.fail_json(msg="Volume cannot be moved into a demoted pod")
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                target_exists = bool(
-                    array.get_volumes(
-                        names=[module.params["move"] + "::" + volume_name],
-                        context_names=[module.params["context"]],
-                    ).status_code
-                    == 200
-                )
-            else:
-                target_exists = bool(
-                    array.get_volumes(
-                        names=[module.params["move"] + "::" + volume_name]
-                    ).status_code
-                    == 200
-                )
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            vgroup_exists = bool(
-                array.get_volume_groups(
-                    names=[module.params["move"]],
-                    context_names=[module.params["context"]],
+            target_exists = bool(
+                get_with_context(
+                    array,
+                    "get_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["move"] + "::" + volume_name],
                 ).status_code
                 == 200
             )
-        else:
-            vgroup_exists = bool(
-                array.get_volume_groups(names=[module.params["move"]]).status_code
+        vgroup_exists = bool(
+            get_with_context(
+                array,
+                "get_volume_groups",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["move"]],
+            ).status_code
+            == 200
+        )
+        if vgroup_exists:
+            target_exists = bool(
+                get_with_context(
+                    array,
+                    "get_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["move"] + "/" + volume_name],
+                ).status_code
                 == 200
             )
-        if vgroup_exists:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                target_exists = bool(
-                    array.get_volumes(
-                        names=[module.params["move"] + "/" + volume_name],
-                        context_names=[module.params["context"]],
-                    ).status_code
-                    == 200
-                )
-            else:
-                target_exists = bool(
-                    array.get_volumes(
-                        names=[module.params["move"] + "/" + volume_name]
-                    ).status_code
-                    == 200
-                )
         if target_exists:
             module.fail_json(msg="Volume of same name already exists in move location")
         if pod_exists and vgroup_exists:
@@ -1612,14 +1429,11 @@ def move_volume(module, array):
                 msg="Move location {0} does not exist.".format(module.params["move"])
             )
         if "::" in module.params["name"] and not vgroup_exists:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                pod = list(array.get_pods(names=[pod_name]).items)[0]
-            else:
-                pod = list(
-                    array.get_pods(
-                        names=[pod_name], context_names=[module.params["context"]]
-                    ).items
-                )[0]
+            pod = list(
+                get_with_context(
+                    array, "get_pods", CONTEXT_API_VERSION, module, names=[pod_name]
+                ).items
+            )[0]
             if pod.array_count > 1:
                 module.fail_json(msg="Volume cannot be moved out of a stretched pod")
             if pod.linked_target_count != 0:
@@ -1643,58 +1457,42 @@ def move_volume(module, array):
     changed = True
     if not module.check_mode:
         if pod_exists:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.patch_volumes(
-                    context_names=[module.params["context"]],
-                    names=[module.params["name"]],
-                    volume=VolumePatch(pod=Reference(name=module.params["move"])),
-                )
-            else:
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePatch(pod=Reference(name=module.params["move"])),
-                )
+            res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                volume=VolumePatch(pod=Reference(name=module.params["move"])),
+            )
         elif vgroup_exists:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.patch_volumes(
-                    context_names=[module.params["context"]],
-                    names=[module.params["name"]],
-                    volume=VolumePatch(
-                        volume_group=Reference(name=module.params["move"])
-                    ),
-                )
-            else:
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePatch(
-                        volume_group=Reference(name=module.params["move"])
-                    ),
-                )
+            res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                volume=VolumePatch(volume_group=Reference(name=module.params["move"])),
+            )
         elif module.params["move"] == "local":
             if "/" in module.params["name"]:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.patch_volumes(
-                        context_names=[module.params["context"]],
-                        names=[module.params["name"]],
-                        volume=VolumePatch(volume_group=Reference(name="")),
-                    )
-                else:
-                    res = array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(volume_group=Reference(name="")),
-                    )
+                res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePatch(volume_group=Reference(name="")),
+                )
             else:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.patch_volumes(
-                        context_names=[module.params["context"]],
-                        names=[module.params["name"]],
-                        volume=VolumePatch(pod=Reference(name="")),
-                    )
-                else:
-                    res = array.patch_volumes(
-                        names=[module.params["name"]],
-                        volume=VolumePatch(pod=Reference(name="")),
-                    )
+                res = patch_with_context(
+                    array,
+                    "patch_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                    volume=VolumePatch(pod=Reference(name="")),
+                )
         check_response(
             res,
             module,
@@ -1713,36 +1511,29 @@ def delete_volume(module, array):
     changed = False
     if module.params["add_to_pgs"]:
         pgs_now = []
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            current_pgs = list(
-                array.get_protection_groups_volumes(
-                    context_names=[module.params["context"]],
-                    member_names=[module.params["name"]],
-                ).items
-            )
-        else:
-            current_pgs = list(
-                array.get_protection_groups_volumes(
-                    member_names=[module.params["name"]]
-                ).items
-            )
+        current_pgs = list(
+            get_with_context(
+                array,
+                "get_protection_groups_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                member_names=[module.params["name"]],
+            ).items
+        )
         for current_pg in current_pgs:
             pgs_now.append(current_pg.group.name)
         old_pgs = list(filter(lambda x: x in module.params["add_to_pgs"], pgs_now))
         if old_pgs:
             changed = True
             if not module.check_mode:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.delete_volumes_protection_groups(
-                        member_names=[module.params["name"]],
-                        group_names=old_pgs,
-                        context_names=[module.params["context"]],
-                    )
-                else:
-                    res = array.delete_volumes_protection_groups(
-                        member_names=[module.params["name"]],
-                        group_names=old_pgs,
-                    )
+                res = delete_with_context(
+                    array,
+                    "delete_volumes_protection_groups",
+                    CONTEXT_API_VERSION,
+                    module,
+                    member_names=[module.params["name"]],
+                    group_names=old_pgs,
+                )
                 check_response(
                     res,
                     module,
@@ -1751,24 +1542,22 @@ def delete_volume(module, array):
     else:
         changed = True
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.patch_volumes(
-                    names=[module.params["name"]],
-                    volume=VolumePatch(destroyed=True),
-                    context_names=[module.params["context"]],
-                )
-            else:
-                res = array.patch_volumes(
-                    names=[module.params["name"]], volume=VolumePatch(destroyed=True)
-                )
+            res = patch_with_context(
+                array,
+                "patch_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+                volume=VolumePatch(destroyed=True),
+            )
             if res.status_code == 200 and module.params["eradicate"]:
-                if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                    res = array.delete_volumes(
-                        names=[module.params["name"]],
-                        context_names=[module.params["context"]],
-                    )
-                else:
-                    res = array.delete_volumes(names=[module.params["name"]])
+                res = delete_with_context(
+                    array,
+                    "delete_volumes",
+                    CONTEXT_API_VERSION,
+                    module,
+                    names=[module.params["name"]],
+                )
                 check_response(
                     res, module, f"Eradicate volume {module.params['name']} failed"
                 )
@@ -1793,13 +1582,13 @@ def eradicate_volume(module, array):
         changed = True
         volfact = []
         if not module.check_mode:
-            if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-                res = array.delete_volumes(
-                    names=[module.params["name"]],
-                    context_names=[module.params["context"]],
-                )
-            else:
-                res = array.delete_volumes(names=[module.params["name"]])
+            res = delete_with_context(
+                array,
+                "delete_volumes",
+                CONTEXT_API_VERSION,
+                module,
+                names=[module.params["name"]],
+            )
             check_response(
                 res, module, f"Eradication of volume {module.params['name']} failed"
             )
@@ -1811,16 +1600,14 @@ def recover_volume(module, array):
     api_version = array.get_rest_version()
     changed = True
     if not module.check_mode:
-        if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
-            res = array.patch_volumes(
-                names=[module.params["name"]],
-                volume=VolumePatch(destroyed=False),
-                context_names=[module.params["context"]],
-            )
-        else:
-            res = array.patch_volumes(
-                names=[module.params["name"]], volume=VolumePatch(destroyed=False)
-            )
+        res = patch_with_context(
+            array,
+            "patch_volumes",
+            CONTEXT_API_VERSION,
+            module,
+            names=[module.params["name"]],
+            volume=VolumePatch(destroyed=False),
+        )
         check_response(
             res, module, f"Recovery of volume {module.params['name']} failed"
         )

--- a/plugins/modules/purefa_workload.py
+++ b/plugins/modules/purefa_workload.py
@@ -697,12 +697,13 @@ def main():
     if module.params["volume_count"] and module.params["volume_count"] <= 0:
         module.fail_json(msg="volume_count must be a positive integer.")
     fleet_res = array.get_fleets()
-    check_response(
-        fleet_res,
-        module,
-        "Fusion is not enabled on this system or the array is not a member of a fleet",
-    )
-    fleet = list(fleet_res.items)[0].name
+    fleet_items = list(fleet_res.items) if fleet_res.status_code == 200 else []
+    if not fleet_items:
+        module.fail_json(
+            msg="purefa_workload requires a Fusion fleet environment, but this "
+            "array is not a member of a fleet."
+        )
+    fleet = fleet_items[0].name
 
     workload_destroyed = False
     workload_exists = False

--- a/tests/unit/plugins/modules/test_purefa_volume.py
+++ b/tests/unit/plugins/modules/test_purefa_volume.py
@@ -40,6 +40,33 @@ sys.modules[
     "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers"
 ] = MagicMock()
 
+
+def _ctx_delegate(client, method_name, context_version, module, **kwargs):
+    """Stand-in for the *_with_context helpers used during migration.
+
+    Mirrors the real helper: call the array method, adding context_names only
+    when the API version supports it and a context is set. This lets the
+    existing array-method-based assertions continue to work.
+    """
+    api_version = client.get_rest_version()
+    if LooseVersion(context_version) <= LooseVersion(api_version) and module.params.get(
+        "context"
+    ):
+        kwargs["context_names"] = [module.params["context"]]
+    return getattr(client, method_name)(**kwargs)
+
+
+_api_helpers_mock = sys.modules[
+    "ansible_collections.purestorage.flasharray.plugins.module_utils.api_helpers"
+]
+for _helper_name in (
+    "get_with_context",
+    "post_with_context",
+    "patch_with_context",
+    "delete_with_context",
+):
+    getattr(_api_helpers_mock, _helper_name).side_effect = _ctx_delegate
+
 from plugins.modules.purefa_volume import (
     main,
     get_volume,


### PR DESCRIPTION
##### SUMMARY

Hardens the collection's Fusion fleet `context` handling so it behaves correctly
on standalone (non-fleet) arrays, and future-proofs it against the FlashArray API
becoming as strict as FlashBlade already is (FlashBlade rejects fleet `context_names`
on an array that is not a member of a fleet, with `Cannot find array in fleet: not in a fleet`).

The collection previously assumed that any context-capable array (REST >= 2.38) was
fleet-enabled: several modules auto-defaulted `context` to the local array name purely
on API version, and the shared helper then sent `context_names` on every call. On a
standalone array that is fine on FlashArray today, but is fragile and would break under
a stricter API.

**Changes**

- **Fleet-gated the auto-default** in `purefa_hg`, `purefa_pg`, `purefa_pgsnap`,
  `purefa_snap`, `purefa_vg`, `purefa_volume`: the context is only defaulted to the
  local array name when `get_fleets()` confirms the array is actually a fleet member.
  On a standalone array `context` stays unset and no `context_names` is sent. This alone
  protects every module that already routes through `api_helpers.*_with_context` (those
  helpers only attach `context_names` when a context is set).

- **`purefa_volume`** — migrated all context-aware API calls to the shared
  `*_with_context` helpers (de-duplicating ~60 inline version checks), so `context_names`
  is only sent when a context is set. Also fixes a pre-existing **inverted version check**
  on the pod-move path that omitted `context_names` on new API versions and sent it on old
  ones.

- **`purefa_workload`** — this module can only operate in a Fusion fleet. It now fails
  fast with a clear message when the array is not a fleet member (previously it could
  `IndexError` on an empty fleet list).

- **`purefa_pgsnap`** — routed the remaining direct context-aware calls through the
  helpers. The volume-restore path keeps its version-specific overwrite /
  `with_default_protection` branches; only the context handling moved to the helper.

- **`purefa_snap`** — gated its two direct context-aware sends on a context being set
  (their surrounding logic differs by snapshot suffix / throttle, so a full helper
  migration there would not be behaviour-preserving).

No change was needed to `api_helpers` itself — the helper design (attach `context_names`
only when version supports it **and** a context is set) was already correct; the issue was
the auto-default feeding it a context on standalone arrays, plus the two modules that
bypassed it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

purefa_hg, purefa_pg, purefa_pgsnap, purefa_snap, purefa_vg, purefa_volume, purefa_workload

##### ADDITIONAL INFORMATION

Behaviour is unchanged for fleet members; only standalone arrays change (they stop
sending fleet context). This mirrors the equivalent fix applied to the FlashBlade
collection.
